### PR TITLE
Kebab case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/tests/items_test.py
+++ b/tests/items_test.py
@@ -312,10 +312,10 @@ def test_add_argument(simple_item, type, required,
 
 
 @pytest.mark.parametrize('default,args,expected', [
-    (True, ['--no-my_bool'], False),
-    (False, ['--my_bool'], True),
-    (None, ['--my_bool'], True),
-    (None, ['--no-my_bool'], False),
+    (True, ['--no-my-bool'], False),
+    (False, ['--my-bool'], True),
+    (None, ['--my-bool'], True),
+    (None, ['--no-my-bool'], False),
     (True, [], None),
     (False, [], None),
 ])
@@ -328,12 +328,12 @@ def test_add_bool_argument(bool_item, default, args, expected):
 
 
 @pytest.mark.parametrize('list_default,child_default,args,expected', [
-    (None, True, ['--my_bool', '--no-my_bool'], [True, False]),
-    (None, False, ['--no-my_bool', '--my_bool'], [False, True]),
+    (None, True, ['--my-bool', '--no-my-bool'], [True, False]),
+    (None, False, ['--no-my-bool', '--my-bool'], [False, True]),
     ([True, False], False, [], None),
     ([True, False], None, [], None),
-    ([True, False], None, ['--my_bool'], [True]),
-    ([True, False], None, ['--no-my_bool'], [False]),
+    ([True, False], None, ['--my-bool'], [True]),
+    ([True, False], None, ['--no-my-bool'], [False]),
 ])
 def test_add_list_boolean_arguments(bool_list_item,
                                     list_default,

--- a/tests/items_test.py
+++ b/tests/items_test.py
@@ -197,12 +197,15 @@ def test_convert_config_value_invalid_bool(bool_item):
 
 
 @pytest.mark.parametrize('env_name,default,config,expected', [
-    ('FOO', None, {'FOO': 'foo_value', 'foo': 'should not be this'}, 'foo_value'),
-    ('FOO', 'default', {'FOO': 'foo_value', 'foo': 'should not be this'}, 'foo_value'),
+    ('FOO', None, {'FOO': 'foo_value', 'foo': 'should not be this'},
+     'foo_value'),
+    ('FOO', 'default', {'FOO': 'foo_value', 'foo': 'should not be this'},
+     'foo_value'),
     ('FOO', 'default', {'FOO': None}, 'default'),
     ('FOO', 'default', {'FOO': ''}, 'default'),
 ])
-def test_get_config_value_from_environment(simple_item, env_name, default, config, expected):
+def test_get_config_value_from_environment(simple_item, env_name,
+                                           default, config, expected):
     simple_item.env_name = env_name
     simple_item.default = default
     value = simple_item.get_config_value([('ENVIRONMENT', config)])

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -458,9 +458,9 @@ def test_load_config_real_world(real_world_spec):
     parser = ArgumentParser(conflict_handler='resolve')
     real_world_spec.add_arguments(parser, bootstrap=True)
     cli_args = ['--file', '/path/to/file.yaml',
-                '--web_port', '1234',
-                '--ssl-public_key', '/path/to/public.crt',
-                '--ssl-private_key', '/path/to/private.key',
+                '--web-port', '1234',
+                '--ssl-public-key', '/path/to/public.crt',
+                '--ssl-private-key', '/path/to/private.key',
                 '--database-verbose'
                 ]
     cli_values = vars(parser.parse_args(cli_args))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import pytest
+import yapconf
+
+
+@pytest.mark.parametrize('orig,expected', [
+    ('CamelCase', 'camel-case'),
+    ('CamelCamelCase', 'camel-camel-case'),
+    ('Camel2Camel2Case', 'camel2-camel2-case'),
+    ('getHTTPResponseCode', 'get-http-response-code'),
+    ('get2HTTPResponseCode', 'get2-http-response-code'),
+    ('HTTPResponseCode', 'http-response-code'),
+    ('HTTPResponseCodeXYZ', 'http-response-code-xyz'),
+    ('snake_case', 'snake-case'),
+    ('snake_snake_case', 'snake-snake-case'),
+    ('snake2_snake2_case', 'snake2-snake2-case'),
+    (' CamelGetHTTPResponse_code_snake2_case is a pain',
+     'camel-get-http-response-code-snake2-case-is-a-pain')
+])
+def test_convert_camel_to_kebab(orig, expected):
+    assert expected == yapconf.change_case(orig)

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Top-level package for Yapconf."""
+import re
 from yapconf.spec import YapconfSpec
 
 yaml_support = True
@@ -24,3 +25,29 @@ if yaml_support:
     FILE_TYPES += ('yaml', )
 
 __all__ = ['YapconfSpec']
+
+
+def change_case(s, separator='-'):
+    """Changes the case to snake/kebab case depending on the separator.
+
+    As regexes can be confusing, I'll just go through this line by line as an example
+    with the following string: ' Foo2Boo_barBaz bat'
+
+    1. Remove whitespaces from beginning/end. => 'Foo2Boo_barBaz bat'
+    2. Replace all remaining spaces with underscores => 'Foo2Boo_barBaz_bat'
+    3. Add underscores before capital letters => 'Foo2_Boo_bar_Baz_bat'
+    4. Replace capital with lowercase => 'foo2_boo_bar_baz_bat'
+    5. Replace underscores with the separator => 'foo2-boo-bar-baz-bat'
+
+    Args:
+        s (str): The original string.
+        separator: The separator you want to use (default '-' for kebab case).
+
+    Returns:
+        A snake_case or kebab-case (depending on separator)
+    """
+    s = s.strip()
+    no_spaces = re.sub(' ', '_', s)
+    add_underscores = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', no_spaces)
+    snake_case = re.sub('([a-z0-9])([A-Z])', r'\1_\2', add_underscores).lower()
+    return re.sub('_', separator, snake_case)

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -30,8 +30,8 @@ __all__ = ['YapconfSpec']
 def change_case(s, separator='-'):
     """Changes the case to snake/kebab case depending on the separator.
 
-    As regexes can be confusing, I'll just go through this line by line as an example
-    with the following string: ' Foo2Boo_barBaz bat'
+    As regexes can be confusing, I'll just go through this line by line as an
+    example with the following string: ' Foo2Boo_barBaz bat'
 
     1. Remove whitespaces from beginning/end. => 'Foo2Boo_barBaz bat'
     2. Replace all remaining spaces with underscores => 'Foo2Boo_barBaz_bat'

--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -158,7 +158,7 @@ class YapconfItem(object):
             based on whether or not this item is part of a nested list.
          separator: A separator used to split apart parent names in the prefix.
          prefix: A delimited list of parent names
-         bootstrap: A flag to detrmine if this item is required for
+         bootstrap: A flag to determine if this item is required for
             bootstrapping the rest of your configuration.
 
     Raises:

--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -257,7 +257,7 @@ class YapconfItem(object):
             kwargs = self._get_argparse_kwargs(bootstrap)
             parser.add_argument(*args, **kwargs)
 
-    def get_config_value(self, overrides, respect_none=False):
+    def get_config_value(self, overrides):
         """Get the configuration value from all overrides.
 
         Iterates over all overrides given to see if a value can be pulled

--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -4,6 +4,7 @@ import sys
 
 import six
 
+import yapconf
 from yapconf.actions import MergeAction, AppendBoolean, AppendReplace
 from yapconf.exceptions import YapconfItemError, YapconfItemNotFound, \
     YapconfValueError, YapconfListItemError, YapconfDictItemError
@@ -466,11 +467,12 @@ class YapconfItem(object):
 
     def _get_argparse_names(self, prefix_chars):
         cli_prefix = self._format_prefix_for_cli(prefix_chars)
+        cli_name = yapconf.change_case(self.name, prefix_chars)
         if self.cli_short_name:
-            return ["{0}{1}".format(cli_prefix, self.name),
+            return ["{0}{1}".format(cli_prefix, cli_name),
                     "{0}{1}".format(prefix_chars, self.cli_short_name)]
         else:
-            return ["{0}{1}".format(cli_prefix, self.name)]
+            return ["{0}{1}".format(cli_prefix, cli_name)]
 
     def _get_argparse_kwargs(self, bootstrap):
         kwargs = {
@@ -575,12 +577,13 @@ class YapconfBoolItem(YapconfItem):
 
     def _get_argparse_names(self, prefix_chars):
         cli_prefix = self._format_prefix_for_cli(prefix_chars)
+        cli_name = yapconf.change_case(self.name, prefix_chars)
         if self.default:
             full_name = "{0}no{1}{2}".format(cli_prefix,
                                              prefix_chars,
-                                             self.name)
+                                             cli_name)
         else:
-            full_name = "{0}{1}".format(cli_prefix, self.name)
+            full_name = "{0}{1}".format(cli_prefix, cli_name)
 
         if self.cli_short_name:
             return [full_name, "{0}{1}".format(prefix_chars,


### PR DESCRIPTION
This is to address #7 

This is basically converting key names to something more sensible on the command-line and in the environment. This will also take into account spaces and the like to at least make the command-line versions of these be semi-predictable. For reference here is what accepting this change will do functionally:


Key Name | Old CLI | New CLI | Old Env | New Env
-------------- | ---------- | ------------ | ---------- | -------------
`camelCase` | `--camelCase` | `--camel-case` | `CAMELCASE` | `CAMEL_CASE`
`snake_case` | `--snake_case` | `--snake-case` | `SNAKE_CASE` | `SNAKE_CASE`
` CamelGetHTTPResponse_code_snake2_dumb name` | `-- CamelGetHTTPResponse_code_snake2_dumb name` | `camel-get-http-response-code-snake2-dumb-name` | ` CAMELGETHTTPRESPONSE_CODE_SNAKE2_DUMB NAME` | `CAMEL_GET_HTTP_RESPONSE_CODE_SNAKE2_DUMB_NAME`


This does not affect how you access the attributes once they have been loaded, only how they are specified on the command line and in the environment. 