### PR TITLE
Importing `open` from io package in Python 2

### DIFF
--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -19,6 +19,8 @@ builtins_path = '__builtin__'
 if sys.version_info > (3,):
     builtins_path = 'builtins'
     long = int
+else:
+    builtins_path = 'yapconf.spec'
 
 original_env = None
 original_yaml_flag = yapconf.yaml_support

--- a/yapconf/spec.py
+++ b/yapconf/spec.py
@@ -3,6 +3,7 @@ import logging
 import json
 import six
 import os
+import sys
 
 from box import Box
 
@@ -10,6 +11,9 @@ import yapconf
 from yapconf.exceptions import YapconfSpecError, YapconfLoadError, \
     YapconfItemNotFound
 from yapconf.items import from_specification
+
+if sys.version_info.major < 3:
+    from io import open
 
 
 class YapconfSpec(object):


### PR DESCRIPTION
Fixes the issue with `encoding` being used with the builtin `open` in Python 2.

In the test it looks like `builtins_path` is only being used to specify how to mock out `open`, so I didn't feel super bad about just using it.