### PR TITLE
Unicode

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,3 +17,4 @@ mock==2.0.0
 six==1.11.0
 python-box==3.1.1
 twine==1.11.0
+future==0.16.0

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'six',
     'python-box',
+    'future',
 ]
 
 test_requirements = [

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -449,10 +449,19 @@ def test_migrate_config_no_mock_create_file(tmpdir, basic_spec):
     assert json.load(new_path) == {"foo": None}
 
 
-def test_migrate_config_no_mock_existing_file(tmpdir, basic_spec):
+@pytest.mark.parametrize('config', [
+    {"foo": None},
+    {"foo": "bar"},
+    {"foo": u"bar"},
+    {"foo": u"\U0001F4A9"},
+    {"foo": u"💩"},
+    {u"\U0001F4A9": "foo"},
+    {u"💩": "foo"},
+    {u"💩": u"💩"},
+])
+def test_migrate_config_no_mock_existing_file(tmpdir, basic_spec, config):
     new_path = tmpdir.join('config.json')
     new_path.ensure()
-    config = {"foo": None}
 
     with new_path.open(mode='w') as fp:
         json.dump(config, fp)

--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import logging
 import sys
 


### PR DESCRIPTION
This should help with #46

First commit is the failing test, second commit is a quick fix to get things to work. If you don't want to depend on `future` (it's 800K) then any literal that could be printing out values will need to be explicitly prefixed with `u` to be safe for Python 2.