### PR TITLE
Made argparse items never required. Fixes #42

### DIFF
--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -511,14 +511,6 @@ class YapconfItem(object):
             raise YapconfItemError("Do not know how to generate CLI "
                                    "type for {0}".format(self.item_type))
 
-    def _get_argparse_required(self, bootstrap):
-        if bootstrap is True and not self.bootstrap:
-            return False
-        elif self.default is None:
-            return self.required
-        else:
-            return False
-
     def _get_argparse_choices(self):
         return self.cli_choices or None
 
@@ -540,7 +532,7 @@ class YapconfItem(object):
             'default': None,
             'type': self._get_argparse_type(),
             'choices': self._get_argparse_choices(),
-            'required': self._get_argparse_required(bootstrap),
+            'required': False,
             'help': self.description,
             'dest': self.fq_name,
         }
@@ -662,7 +654,7 @@ class YapconfBoolItem(YapconfItem):
         kwargs = {
             'action': self._get_argparse_action(),
             'default': None,
-            'required': self._get_argparse_required(bootstrap),
+            'required': False,
             'help': self.description,
             'dest': self.fq_name,
         }


### PR DESCRIPTION
Argparse arguments should never really be marked as required. We don't
have enough information to mark them as required. Everything yapconf
does with the CLI is just helpful options. We assume that if they are
not provided on the command-line, they will be added by a different
source later.