### PR TITLE
Fixes #74

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,11 @@
 History
 =======
 
-0.3.0 TBD
+0.3.1 (2018-06-07)
+---------
+* Fixed an issue with environment loading (#74)
+
+0.3.0 (2018-06-02)
 ---------
 * Fixed an issue where utf-8 migrations would break (#46)
 * Added support for etcd (#47)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 """The setup script."""
 
 from setuptools import find_packages, setup
@@ -43,7 +43,7 @@ extras = {
 
 setup(
     name='yapconf',
-    version='0.3.0',
+    version='0.3.1',
     description="Yet Another Python Configuration",
     long_description=readme + '\n\n' + history,
     author="Logan Asher Jones",

--- a/tests/sources_test.py
+++ b/tests/sources_test.py
@@ -134,3 +134,8 @@ def test_etcd_watch():
         source._watch(handler, {})
 
     handler.handle_config_change('NEW_DATA')
+
+
+def test_environment():
+    source = get_source('label', 'environment')
+    assert isinstance(source.get_data(), dict)

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -555,6 +555,12 @@ def test_load_from_source(
     assert config == example_data
 
 
+def test_load_environment(basic_spec):
+    os.environ['FOO'] = 'foo_value'
+    config = basic_spec.load_config('ENVIRONMENT')
+    assert config.foo == 'foo_value'
+
+
 @pytest.mark.usefixtures('simple_spec')
 @pytest.mark.parametrize('key,config_type,formatter', [
     (None, None, None),

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -50,7 +50,7 @@ from yapconf.spec import YapconfSpec  # noqa: E402
 
 __author__ = """Logan Asher Jones"""
 __email__ = 'loganasherjones@gmail.com'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 FILE_TYPES = {'json', }

--- a/yapconf/sources.py
+++ b/yapconf/sources.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import abc
-import copy
 import hashlib
 import json
 import os
@@ -335,7 +334,7 @@ class EnvironmentConfigSource(DictConfigSource):
         self.type = 'environment'
 
     def get_data(self):
-        return copy.deepcopy(os.environ)
+        return os.environ.copy()
 
 
 class EtcdConfigSource(ConfigSource):


### PR DESCRIPTION
Using `deepcopy` on the os.environ results in
an object instead of a dictionary. Just using
copy should be sufficient.