### PR TITLE
Fixes #75

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.3.1 (2018-06-07)
 ---------
 * Fixed an issue with environment loading (#74)
+* Fixed an issue with watching in-memory dictionaries (#75)
 
 0.3.0 (2018-06-02)
 ---------

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -870,13 +870,15 @@ def test_watchers(real_world_spec, label):
     real_world_spec.add_source('label3', 'dict', data=safe_data)
 
     real_world_spec.spawn_watcher(label, target=overall_handler)
+    time.sleep(0.1)
 
     change_config(label)
 
     wait_time = 0.0
 
-    while any(flags.values()) and wait_time <= 90:
+    while any(flags.values()) and wait_time <= 3:
         time.sleep(0.25)
         wait_time += 0.25
 
-    assert not all(flags.values())
+    for flag in flags.values():
+        assert not flag

--- a/yapconf/handlers.py
+++ b/yapconf/handlers.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import copy
+
 from watchdog.events import RegexMatchingEventHandler
 
 import yapconf
@@ -12,7 +14,9 @@ class ConfigChangeHandler(object):
     """
 
     def __init__(self, current_config, spec, user_handler=None):
-        self.current_config = current_config
+        # We perform a deep copy so that we can accurately assess whether
+        # or not the value has changed for in-memory dictionaries.
+        self.current_config = copy.deepcopy(current_config)
         self.spec = spec
         self.user_handler = user_handler
 
@@ -26,7 +30,7 @@ class ConfigChangeHandler(object):
         if self.user_handler:
             self.user_handler(self.current_config, new_config)
         self._call_spec_handlers(new_config)
-        self.current_config = new_config
+        self.current_config = copy.deepcopy(new_config)
 
     def _call_spec_handlers(self, new_config):
         flattened_config = yapconf.flatten(new_config, self.spec._separator)


### PR DESCRIPTION
In memory dictionaries would be auto-updated and thus the
item watch functions would never get called. Performing
a deep copy of the current config on init and when the
config changes ensures that we are comparing new
dictionaries when someone changes the in-memory dict.