### PR TITLE
Adding CLI config source

### DIFF
--- a/tests/sources_test.py
+++ b/tests/sources_test.py
@@ -4,11 +4,12 @@ from etcd import EtcdWatchTimedOut
 from mock import Mock, PropertyMock, patch
 
 import yapconf
+from yapconf import YapconfSpec
 from yapconf.exceptions import YapconfSourceError
 from yapconf.sources import (DictConfigSource, EnvironmentConfigSource,
                              EtcdConfigSource, JsonConfigSource,
                              KubernetesConfigSource, YamlConfigSource,
-                             get_source)
+                             CliConfigSource, get_source)
 
 original_sources = yapconf.SUPPORTED_SOURCES.copy()
 
@@ -25,6 +26,7 @@ def teardown_function(function):
     ('yaml', yapconf.SUPPORTED_SOURCES, {}),
     ('etcd', yapconf.SUPPORTED_SOURCES, {'client': 'NOT_A_ETCD_CLIENT'}),
     ('kubernetes', yapconf.SUPPORTED_SOURCES, {'client': 'NOT_A_K8S_CLIENT'}),
+    ('cli', yapconf.SUPPORTED_SOURCES, {}),
 ])
 def test_get_source_error(source_type, sources, kwargs):
     yapconf.SUPPORTED_SOURCES = sources
@@ -40,7 +42,8 @@ def test_get_source_error(source_type, sources, kwargs):
     (
         'etcd',
         {'client': Mock(spec=yapconf.etcd_client.Client)},
-        EtcdConfigSource),
+        EtcdConfigSource
+    ),
     (
         'kubernetes',
         {
@@ -49,6 +52,7 @@ def test_get_source_error(source_type, sources, kwargs):
         },
         KubernetesConfigSource
     ),
+    ('cli', {'spec': YapconfSpec({})}, CliConfigSource),
 ])
 def test_get_source(source_type, kwargs, klazz):
     source = get_source('label', source_type, **kwargs)

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -60,6 +60,7 @@ SUPPORTED_SOURCES = {
     'dict',
     'environment',
     'json',
+    'cli',
 }
 ALL_SUPPORTED_SOURCES = {
     'dict',
@@ -68,6 +69,7 @@ ALL_SUPPORTED_SOURCES = {
     'json',
     'kubernetes',
     'yaml',
+    'cli',
 }
 
 if yaml_support:

--- a/yapconf/spec.py
+++ b/yapconf/spec.py
@@ -550,6 +550,8 @@ class YapconfSpec(object):
             return self._sources[value]
         elif value == 'ENVIRONMENT':
             return get_source(value, 'environment')
+        elif value == 'CLI':
+            return get_source(value, 'cli', spec=self)
         elif file_type in ['json', 'yaml']:
             return get_source(
                 value,


### PR DESCRIPTION
This PR adds support for a special "CLI" source similar to the "ENVIRONMENT" source.

The current structure for sources seems to be that all the information needed to successfully load the source must be provided as kwargs to the `ConfigSource` class. That's why the spec is passed in as a kwarg.