### PR TITLE
DictItem apply_filter now excludes logger attribute from deep copy

### DIFF
--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -138,7 +138,7 @@ def test_nested_load_config(spec_with_dicts):
                 "port": 3306,
                 "verbose": False,
             },
-            "emoji": "💩",
+            "emoji": u"💩",
         }
     ),
 ])

--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -838,6 +838,10 @@ class YapconfDictItem(YapconfItem):
             raise YapconfDictItemError('Dict item {0} must have children'
                                        .format(self.name))
 
+    def __deepcopy__(self, memodict={}):
+        kwargs = {k: v for k, v in self.__dict__.items() if k != "logger"}
+        return YapconfDictItem(**kwargs)
+
     def _setup_env_name(self, env_name):
         self.env_name = None
 
@@ -896,9 +900,9 @@ class YapconfDictItem(YapconfItem):
         if not filtered_items:
             return None
         else:
-            kwargs = copy.deepcopy(self.__dict__)
-            kwargs["children"] = filtered_items
-            return YapconfDictItem(**kwargs)
+            obj_copy = copy.deepcopy(self)
+            obj_copy.children = filtered_items
+            return obj_copy
 
     def migrate_config(self, current_config, config_to_migrate,
                        always_update, update_defaults):


### PR DESCRIPTION
This PR fixes a test that was failing in the Python 2.7 and 3.6 Travis builds. It seems like the deepcopy was failing because it was trying to also copy the item's logger instance, which has an unpickable attribute. This PR excludes the logger from the deepcopy.

It also marks a test emoji as unicode so the test doesn't fail in Python 2.