### PR TITLE
Added support for ruamel.yaml 0.18

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.4.0 ()
+------------------
+* Added support for `ruamel.yaml>0.18`
+
 0.3.7 (2019-12-02)
 ------------------
 * Fixed broken test

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -34,8 +34,8 @@ try:
     # ruamel.yaml is installed.
     import ruamel.yaml as yaml
 
+    # ruamel.yaml depricated support for safe_load in 0.17.0
     if packaging.version.parse(yaml.__version__) < packaging.version.parse("0.18.0"):
-        # ruamel.yaml depricated support for safe_load in 0.17.0
         yaml.load = yaml.safe_load
     else:
         from ruamel.yaml import YAML


### PR DESCRIPTION
Added check to utilize the updated safe loading method. Also dropped `safe_load` when provided a yaml for `load` since it was mapped over at the start of the `__init__.py`

fixes: #105