### PR TITLE
Upgrade ruamel.yaml 

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ["3.8","3.9","3.10","3.11.11","3.12","3.13", "3.14"]
         os: ["ubuntu-latest"]
 
-    name: PyTests OS ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    name: PyTests Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
 
@@ -51,6 +51,9 @@ jobs:
 
       - name: Make Deps
         run: pip install -r requirements.txt
+
+      - name: Install ruamel.yaml
+        run: pip install ruamel.yaml>=0.15
 
       - name: Run Tests
         run: make test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,8 +52,5 @@ jobs:
       - name: Make Deps
         run: pip install -r requirements.txt
 
-      - name: Install ruamel.yaml
-        run: pip install ruamel.yaml>=0.15
-
       - name: Run Tests
         run: make test

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,13 @@
 History
 =======
 
-0.4.0 ()
+0.5.0 ()
+------------------
+* Removed Python 2 support, min version tested is Python 3.8
+* Removed Six dependency
+* Upgraded Python-Box 
+
+0.4.0 (2024-11-12)
 ------------------
 * Added support for `ruamel.yaml>0.18`
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "six<2",
-    "python-box<4",
+    "python-box<8",
 ]
 
 extras = {
@@ -60,15 +59,14 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     test_suite="tests",
     tests_require=extras["test"],

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ extras = {
         "pytest-cov",
         "pytest-runner",
         "python-etcd",
-        "ruamel.yaml",
+        "ruamel.yaml>=0.15",
         "tox",
     ],
-    "yaml": ["ruamel.yaml"],
+    "yaml": ["ruamel.yaml>=0.15"],
 }
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,23 +11,23 @@ from yapconf.items import from_specification
 @pytest.fixture
 def simple_item_spec():
     """A specification for a string item."""
-    return {'foo': {}}
+    return {"foo": {}}
 
 
 @pytest.fixture
 def bool_item_spec():
     """A specification for a boolean item."""
-    return {'my_bool': {'type': 'bool', 'required': True}}
+    return {"my_bool": {"type": "bool", "required": True}}
 
 
 @pytest.fixture
 def unformatted_item_spec():
     """A specification for an unformatted string item."""
     return {
-        'weirdName-Cool_stuff lol': {
-            'required': True,
-            'format_env': False,
-            'format_cli': False,
+        "weirdName-Cool_stuff lol": {
+            "required": True,
+            "format_env": False,
+            "format_cli": False,
         }
     }
 
@@ -36,11 +36,11 @@ def unformatted_item_spec():
 def unformatted_bool_item_spec():
     """A specification for an unformatted boolean item."""
     return {
-        'weirdName-Cool_stuff lol': {
-            'type': 'bool',
-            'required': True,
-            'format_env': False,
-            'format_cli': False,
+        "weirdName-Cool_stuff lol": {
+            "type": "bool",
+            "required": True,
+            "format_env": False,
+            "format_cli": False,
         }
     }
 
@@ -48,42 +48,32 @@ def unformatted_bool_item_spec():
 @pytest.fixture
 def list_item_spec(simple_item_spec):
     """A specification for a list item."""
-    return {
-        'foos': {
-            'required': True,
-            'items': {'simple_item': simple_item_spec}
-        }
-    }
+    return {"foos": {"required": True, "items": {"simple_item": simple_item_spec}}}
 
 
 @pytest.fixture
 def bool_list_item_spec(bool_item_spec):
     """A specification for a list of boolean items."""
-    return {
-        'my_bools': {
-            'required': True,
-            'items': bool_item_spec
-        }
-    }
+    return {"my_bools": {"required": True, "items": bool_item_spec}}
 
 
 @pytest.fixture
 def simple_item(simple_item_spec):
     """A YacponfItem for a string config value."""
-    return from_specification(simple_item_spec)['foo']
+    return from_specification(simple_item_spec)["foo"]
 
 
 @pytest.fixture
 def bool_item(bool_item_spec):
     """A YacponfItem for a boolean config value."""
-    return from_specification(bool_item_spec)['my_bool']
+    return from_specification(bool_item_spec)["my_bool"]
 
 
 @pytest.fixture
 def unformatted_item(unformatted_item_spec):
     """A YapconfItem for an unformatted string value."""
     items = from_specification(unformatted_item_spec)
-    return items['weirdName-Cool_stuff lol']
+    return items["weirdName-Cool_stuff lol"]
 
 
 @pytest.fixture
@@ -91,42 +81,31 @@ def unformatted_bool_item(unformatted_bool_item_spec):
     """A YapconfItem for an unformatted boolean value."""
     # unformatted_item_spec['type'] = 'bool'
     items = from_specification(unformatted_bool_item_spec)
-    return items['weirdName-Cool_stuff lol']
+    return items["weirdName-Cool_stuff lol"]
 
 
 @pytest.fixture
 def list_item(simple_item_spec):
     """A YapconfItem for a list value."""
-    return from_specification({
-        'foos': {
-            'type': 'list',
-            'items': {
-                'simple_item': simple_item_spec
-            }
-        }
-    })['foos']
+    return from_specification(
+        {"foos": {"type": "list", "items": {"simple_item": simple_item_spec}}}
+    )["foos"]
 
 
 @pytest.fixture
 def bool_list_item(bool_item_spec):
     """A YapconfItem for a list of boolean values."""
-    return from_specification({
-        'my_bools': {
-            'type': 'list',
-            'items': bool_item_spec
-        }
-    })['my_bools']
+    return from_specification({"my_bools": {"type": "list", "items": bool_item_spec}})[
+        "my_bools"
+    ]
 
 
 @pytest.fixture
 def dict_item(simple_item_spec):
     """A YapconfItem for a dictionary."""
-    return from_specification({
-        'foo_dict': {
-            'type': 'dict',
-            'items': {'foo': simple_item_spec}
-        }
-    })['foo_dict']
+    return from_specification(
+        {"foo_dict": {"type": "dict", "items": {"foo": simple_item_spec}}}
+    )["foo_dict"]
 
 
 @pytest.fixture
@@ -134,49 +113,43 @@ def db_item():
     """A YapconfItem for a dictionary that represents a db config."""
     return from_specification(
         {
-            'db': {
-                'type': 'dict',
-                'items': {
-                    'name': {
-                        'required': True,
-                        'alt_env_names': ['ALT_NAME'],
+            "db": {
+                "type": "dict",
+                "items": {
+                    "name": {
+                        "required": True,
+                        "alt_env_names": ["ALT_NAME"],
                     },
-                    'port': {
-                        'required': True,
-                        'type': 'int',
+                    "port": {
+                        "required": True,
+                        "type": "int",
                     },
-                    'verbose': {
-                        'required': True,
-                        'type': 'bool',
+                    "verbose": {
+                        "required": True,
+                        "type": "bool",
                     },
-                    'users': {
-                        'type': 'list',
-                        'required': True,
-                        'items': {
-                            'user': {
-                                'required': True,
-                                'type': 'str',
+                    "users": {
+                        "type": "list",
+                        "required": True,
+                        "items": {
+                            "user": {
+                                "required": True,
+                                "type": "str",
                             },
                         },
                     },
-                    'log': {
-                        'type': 'dict',
-                        'required': True,
-                        'items': {
-                            'level': {
-                                'required': True,
-                                'type': 'str'
-                            },
-                            'file': {
-                                'required': True,
-                                'type': 'str'
-                            },
+                    "log": {
+                        "type": "dict",
+                        "required": True,
+                        "items": {
+                            "level": {"required": True, "type": "str"},
+                            "file": {"required": True, "type": "str"},
                         },
                     },
                 },
             },
         },
-    )['db']
+    )["db"]
 
 
 @pytest.fixture
@@ -190,12 +163,30 @@ def simple_spec():
     """Simple YapconfSpec for all YapconfItem variations"""
     return YapconfSpec(
         {
-            'my_string': {'type': 'str', 'required': True, },
-            'my_int': {'type': 'int', 'required': True, },
-            'my_long': {'type': 'long', 'required': True, },
-            'my_float': {'type': 'float', 'required': True, },
-            'my_bool': {'type': 'bool', 'required': True, },
-            'my_complex': {'type': 'complex', 'required': True, },
+            "my_string": {
+                "type": "str",
+                "required": True,
+            },
+            "my_int": {
+                "type": "int",
+                "required": True,
+            },
+            "my_long": {
+                "type": "long",
+                "required": True,
+            },
+            "my_float": {
+                "type": "float",
+                "required": True,
+            },
+            "my_bool": {
+                "type": "bool",
+                "required": True,
+            },
+            "my_complex": {
+                "type": "complex",
+                "required": True,
+            },
         }
     )
 
@@ -205,45 +196,44 @@ def spec_with_lists():
     """YapconfSpec for testing YapconfListItem variations"""
     return YapconfSpec(
         {
-            'simple_list': {
-                'type': 'list',
-                'required': True,
-                'items': {
-                    'list_item': {
-                        'type': 'str', 'required': True
-                    }
-                }
+            "simple_list": {
+                "type": "list",
+                "required": True,
+                "items": {"list_item": {"type": "str", "required": True}},
             },
-            'top_list': {
-                'type': 'list',
-                'required': True,
-                'items': {
-                    'nested_list': {
-                        'type': 'list',
-                        'required': True,
-                        'items': {
-                            'nested_list_items': {
-                                'type': 'int',
-                                'required': True
-                            }
-                        }
+            "top_list": {
+                "type": "list",
+                "required": True,
+                "items": {
+                    "nested_list": {
+                        "type": "list",
+                        "required": True,
+                        "items": {
+                            "nested_list_items": {"type": "int", "required": True}
+                        },
                     }
-                }
+                },
             },
-            'list_of_dictionaries': {
-                'type': 'list',
-                'required': True,
-                'items': {
-                    'list_item': {
-                        'type': 'dict',
-                        'required': True,
-                        'items': {
-                            'foo': {'type': 'str', 'required': True, },
-                            'bar': {'type': 'str', 'required': False, }
-                        }
+            "list_of_dictionaries": {
+                "type": "list",
+                "required": True,
+                "items": {
+                    "list_item": {
+                        "type": "dict",
+                        "required": True,
+                        "items": {
+                            "foo": {
+                                "type": "str",
+                                "required": True,
+                            },
+                            "bar": {
+                                "type": "str",
+                                "required": False,
+                            },
+                        },
                     }
-                }
-            }
+                },
+            },
         }
     )
 
@@ -251,111 +241,101 @@ def spec_with_lists():
 @pytest.fixture
 def spec_with_dicts():
     """YapconfSpec for testing YapconfDictItem variations"""
-    return YapconfSpec({
-        'database': {
-            'type': 'dict',
-            'required': True,
-            'items': {
-                'name': {'type': 'str', 'required': True, },
-                'host': {'type': 'str', 'required': True, },
-                'port': {'type': 'int', 'required': True, },
-            }
-        },
-        'foo': {
-            'type': 'dict',
-            'required': True,
-            'items': {
-                'bar': {
-                    'type': 'dict',
-                    'required': True,
-                    'items': {
-                        'baz': {
-                            'type': 'str', 'required': True,
-                        },
+    return YapconfSpec(
+        {
+            "database": {
+                "type": "dict",
+                "required": True,
+                "items": {
+                    "name": {
+                        "type": "str",
+                        "required": True,
+                    },
+                    "host": {
+                        "type": "str",
+                        "required": True,
+                    },
+                    "port": {
+                        "type": "int",
+                        "required": True,
                     },
                 },
-                'bat': {
-                    'type': 'bool',
-                }
             },
-        },
-    })
+            "foo": {
+                "type": "dict",
+                "required": True,
+                "items": {
+                    "bar": {
+                        "type": "dict",
+                        "required": True,
+                        "items": {
+                            "baz": {
+                                "type": "str",
+                                "required": True,
+                            },
+                        },
+                    },
+                    "bat": {
+                        "type": "bool",
+                    },
+                },
+            },
+        }
+    )
 
 
 @pytest.fixture
 def real_world_spec():
     """YapconfSpec based on a 'real-world' example"""
     current_dir = os.path.abspath(os.path.dirname(__file__))
-    filename = os.path.join(current_dir, 'files', 'real_world', 'spec.yaml')
-    return YapconfSpec(filename, file_type='yaml', env_prefix='MY_APP_')
+    filename = os.path.join(current_dir, "files", "real_world", "spec.yaml")
+    return YapconfSpec(filename, file_type="yaml", env_prefix="MY_APP_")
 
 
 @pytest.fixture
 def current_config():
     current_dir = os.path.abspath(os.path.dirname(__file__))
-    filename = os.path.join(
-        current_dir,
-        'files',
-        'real_world',
-        'current_config.yaml'
-    )
-    return yapconf.load_file(filename, 'yaml')
+    filename = os.path.join(current_dir, "files", "real_world", "current_config.yaml")
+    return yapconf.load_file(filename, "yaml")
 
 
 @pytest.fixture
 def previous_config():
     current_dir = os.path.abspath(os.path.dirname(__file__))
-    filename = os.path.join(
-        current_dir,
-        'files',
-        'real_world',
-        'previous_config.yaml'
-    )
-    return yapconf.load_file(filename, 'yaml')
+    filename = os.path.join(current_dir, "files", "real_world", "previous_config.yaml")
+    return yapconf.load_file(filename, "yaml")
 
 
 @pytest.fixture
 def default_current_config():
     current_dir = os.path.abspath(os.path.dirname(__file__))
     filename = os.path.join(
-        current_dir,
-        'files',
-        'real_world',
-        'default_current_config.yaml'
+        current_dir, "files", "real_world", "default_current_config.yaml"
     )
-    return yapconf.load_file(filename, 'yaml')
+    return yapconf.load_file(filename, "yaml")
 
 
 @pytest.fixture
 def default_previous_config():
     current_dir = os.path.abspath(os.path.dirname(__file__))
     filename = os.path.join(
-        current_dir,
-        'files',
-        'real_world',
-        'default_previous_config.yaml'
+        current_dir, "files", "real_world", "default_previous_config.yaml"
     )
-    return yapconf.load_file(filename, 'yaml')
+    return yapconf.load_file(filename, "yaml")
 
 
 @pytest.fixture
 def example_spec():
     return YapconfSpec(
         {
-            'foo': {},
-            'emoji': {},
-            u'💩': {},
-            'db': {
-                'type': 'dict',
-                'items': {
-                    'name': {},
-                    'port': {'type': 'int'}
-                }
-            },
-            'items': {
-                'type': 'list',
-                'items': {
-                    'item': {'type': 'int'},
+            "foo": {},
+            "emoji": {},
+            "💩": {},
+            "db": {"type": "dict", "items": {"name": {}, "port": {"type": "int"}}},
+            "items": {
+                "type": "list",
+                "items": {
+                    "item": {"type": "int"},
                 },
             },
         }
@@ -366,68 +346,57 @@ def example_spec():
 def example_data():
     return {
         "foo": "bar",
-        "emoji": u"💩",
-        u"💩": u"🐍",
-        "db": {
-            "name": "db_name",
-            "port": 123
-        },
-        "items": [1, 2, 3]
+        "emoji": "💩",
+        "💩": "🐍",
+        "db": {"name": "db_name", "port": 123},
+        "items": [1, 2, 3],
     }
 
 
 @pytest.fixture
 def fallback_spec():
-    return YapconfSpec({
-        'defaults': {
-            'type': 'dict',
-            'items': {
-                'str': {'type': 'str', 'default': 'default_str'},
-                'int': {'type': 'int', 'default': 123},
-                'long': {'type': 'long', 'default': 123},
-                'float': {'type': 'float', 'default': 123.123},
-                'bool': {'type': 'bool', 'default': True},
-                'complex': {'type': 'complex', 'default': 1j},
-                'list': {
-                    'type': 'list',
-                    'default': [1, 2, 3],
-                    'items': {
-                        'list_item': {'type': 'int', 'default': 1}
+    return YapconfSpec(
+        {
+            "defaults": {
+                "type": "dict",
+                "items": {
+                    "str": {"type": "str", "default": "default_str"},
+                    "int": {"type": "int", "default": 123},
+                    "long": {"type": "long", "default": 123},
+                    "float": {"type": "float", "default": 123.123},
+                    "bool": {"type": "bool", "default": True},
+                    "complex": {"type": "complex", "default": 1j},
+                    "list": {
+                        "type": "list",
+                        "default": [1, 2, 3],
+                        "items": {"list_item": {"type": "int", "default": 1}},
+                    },
+                    "dict": {
+                        "type": "dict",
+                        "default": {"foo": "dict_default"},
+                        "items": {"foo": {"type": "str", "default": "item_default"}},
                     },
                 },
-                'dict': {
-                    'type': 'dict',
-                    'default': {'foo': 'dict_default'},
-                    'items': {
-                        'foo': {'type': 'str', 'default': 'item_default'}
-                    },
+            },
+            "str": {"type": "str", "fallback": "defaults.str"},
+            "int": {"type": "int", "fallback": "defaults.int"},
+            "long": {"type": "long", "fallback": "defaults.long"},
+            "float": {"type": "float", "fallback": "defaults.float"},
+            "bool": {"type": "bool", "fallback": "defaults.bool"},
+            "complex": {"type": "complex", "fallback": "defaults.complex"},
+            "list": {
+                "type": "list",
+                "fallback": "defaults.list",
+                "items": {
+                    "list_item": {"type": "int", "fallback": "defaults.list.list_item"},
                 },
             },
-        },
-        'str': {'type': 'str', 'fallback': 'defaults.str'},
-        'int': {'type': 'int', 'fallback': 'defaults.int'},
-        'long': {'type': 'long', 'fallback': 'defaults.long'},
-        'float': {'type': 'float', 'fallback': 'defaults.float'},
-        'bool': {'type': 'bool', 'fallback': 'defaults.bool'},
-        'complex': {'type': 'complex', 'fallback': 'defaults.complex'},
-        'list': {
-            'type': 'list',
-            'fallback': 'defaults.list',
-            'items': {
-                'list_item': {
-                    'type': 'int',
-                    'fallback': 'defaults.list.list_item'
+            "dict": {
+                "type": "dict",
+                "fallback": "defaults.dict",
+                "items": {
+                    "foo": {"type": "str", "fallback": "defaults.dict.foo"},
                 },
             },
-        },
-        'dict': {
-            'type': 'dict',
-            'fallback': 'defaults.dict',
-            'items': {
-                'foo': {
-                    'type': 'str',
-                    'fallback': 'defaults.dict.foo'
-                },
-            },
-        },
-    })
+        }
+    )

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -5,28 +5,30 @@ from yapconf.docs import build_markdown_table
 
 # flake8: noqa
 def test_build_markdown_table():
-    headers = {'foo': 'Foo', 'bar': 'Bar'}
+    headers = {"foo": "Foo", "bar": "Bar"}
     rows = [
         {
-            'bar': 'bar_value',
-            'foo': 'x',
+            "bar": "bar_value",
+            "foo": "x",
         },
         {
-            'bar': 'bar_value2',
-            'foo': 'y',
+            "bar": "bar_value2",
+            "foo": "y",
         },
     ]
-    table = build_markdown_table(headers, rows, ['foo', 'bar'])
-    assert table == ("| Foo | Bar        |\n"
-                     "| --- | ---------- |\n"
-                     "| x   | bar_value  |\n"
-                     "| y   | bar_value2 |\n")
+    table = build_markdown_table(headers, rows, ["foo", "bar"])
+    assert table == (
+        "| Foo | Bar        |\n"
+        "| --- | ---------- |\n"
+        "| x   | bar_value  |\n"
+        "| y   | bar_value2 |\n"
+    )
 
 
 def test_generate_markdown_doc_simple(simple_spec):
-    doc = simple_spec.generate_documentation('My App Name')
+    doc = simple_spec.generate_documentation("My App Name")
     assert doc == (
-"""# My App Name Configuration
+        """# My App Name Configuration
 
 This document describes the configuration for My App Name. Each section will 
 document a particular configuration value and its description. First, 

--- a/tests/handlers_test.py
+++ b/tests/handlers_test.py
@@ -7,16 +7,14 @@ from yapconf.handlers import ConfigChangeHandler, FileHandler
 
 
 def test_handle_config_change(simple_spec):
-    current_config = {'my_string': 'foo'}
-    new_config = {'my_string': 'bar'}
+    current_config = {"my_string": "foo"}
+    new_config = {"my_string": "bar"}
     user_handler = Mock()
     item_handler = Mock()
 
-    handler = ConfigChangeHandler(
-        current_config, simple_spec, user_handler
-    )
+    handler = ConfigChangeHandler(current_config, simple_spec, user_handler)
 
-    item = simple_spec.find_item('my_string')
+    item = simple_spec.find_item("my_string")
     item.watch_target = item_handler
 
     handler.handle_config_change(current_config)
@@ -28,16 +26,14 @@ def test_handle_config_change(simple_spec):
 
 
 def test_handle_config_change_too_many_items(simple_spec):
-    current_config = {'my_string': 'foo'}
-    new_config = {'NOT_IN_SPEC': 'bar'}
+    current_config = {"my_string": "foo"}
+    new_config = {"NOT_IN_SPEC": "bar"}
     user_handler = Mock()
     item_handler = Mock()
 
-    handler = ConfigChangeHandler(
-        current_config, simple_spec, user_handler
-    )
+    handler = ConfigChangeHandler(current_config, simple_spec, user_handler)
 
-    item = simple_spec.find_item('my_string')
+    item = simple_spec.find_item("my_string")
     item.watch_target = item_handler
 
     handler.handle_config_change(new_config)
@@ -47,15 +43,15 @@ def test_handle_config_change_too_many_items(simple_spec):
 
 def test_file_handler():
     custom_handler = Mock()
-    handler = FileHandler('filename', custom_handler)
+    handler = FileHandler("filename", custom_handler)
 
-    with patch('yapconf.load_file') as mock_load:
+    with patch("yapconf.load_file") as mock_load:
         mock_load.return_value = "new_config"
         handler.on_modified(None)
-        custom_handler.handle_config_change.assert_called_with('new_config')
+        custom_handler.handle_config_change.assert_called_with("new_config")
 
 
 def test_file_handler_on_deleted():
-    handler = FileHandler('filename', Mock())
+    handler = FileHandler("filename", Mock())
     with pytest.raises(YapconfSourceError):
         handler.on_deleted(None)

--- a/tests/items_test.py
+++ b/tests/items_test.py
@@ -15,86 +15,77 @@ if sys.version_info > (3,):
     long = int
 
 
-@pytest.mark.parametrize('clazz,kwargs,env_names', [
-    (
-        YapconfItem,
-        {'name': 'foo', 'env_name': None, 'alt_env_names': []},
-        ['FOO']
-    ),
-    (
-        YapconfItem,
-        {'name': 'foo', 'env_name': None, 'alt_env_names': ['bar']},
-        ['FOO', 'bar']
-    ),
-    (
-        YapconfItem,
-        {'name': 'foo', 'env_name': None, 'alt_env_names': ['bar'],
-         'env_prefix': 'MY_APP_'},
-        ['MY_APP_FOO', 'MY_APP_bar']
-    ),
-    (
-        YapconfListItem,
-        {
-            'name': 'foos',
-            'env_name': 'FOOS',
-            'alt_env_names': ['BARS'],
-            'children': {'foo': YapconfItem('foo')}
-        },
-        []
-    )
-])
+@pytest.mark.parametrize(
+    "clazz,kwargs,env_names",
+    [
+        (YapconfItem, {"name": "foo", "env_name": None, "alt_env_names": []}, ["FOO"]),
+        (
+            YapconfItem,
+            {"name": "foo", "env_name": None, "alt_env_names": ["bar"]},
+            ["FOO", "bar"],
+        ),
+        (
+            YapconfItem,
+            {
+                "name": "foo",
+                "env_name": None,
+                "alt_env_names": ["bar"],
+                "env_prefix": "MY_APP_",
+            },
+            ["MY_APP_FOO", "MY_APP_bar"],
+        ),
+        (
+            YapconfListItem,
+            {
+                "name": "foos",
+                "env_name": "FOOS",
+                "alt_env_names": ["BARS"],
+                "children": {"foo": YapconfItem("foo")},
+            },
+            [],
+        ),
+    ],
+)
 def test_env_names(clazz, kwargs, env_names):
     item = clazz(**kwargs)
     item = clazz(**kwargs)
     assert item.all_env_names == env_names
 
 
-@pytest.mark.parametrize('clazz,kwargs,error_clazz', [
-    (
-        YapconfItem,
-        {'name': 'foo', 'item_type': 'INVALID_TYPE'},
-        YapconfItemError
-    ),
-    (
-        YapconfItem,
-        {'name': 'foo', 'choices': ['a'], 'default': 'b'},
-        YapconfValueError
-    ),
-    (
-        YapconfItem,
-        {'name': 'foo', 'cli_short_name': 'too_long'},
-        YapconfItemError
-    ),
-    (
-        YapconfItem,
-        {'name': 'foo', 'cli_short_name': '-'},
-        YapconfItemError
-    ),
-    (
-        YapconfDictItem,
-        {'name': 'foo', 'children': {}},
-        YapconfDictItemError
-    ),
-    (
-        YapconfDictItem,
-        {
-            'name': 'foo',
-            'children': {'item1': YapconfItem('simple_item')},
-            'choices': [{'foo': 'bar'}]
-        },
-        YapconfDictItemError
-    ),
-    (
-        YapconfListItem,
-        {
-            'name': 'foo',
-            'children': {
-                'item1': YapconfItem('simple_item'),
-                'item2': YapconfBoolItem('my_bool')}
-        },
-        YapconfListItemError
-    )
-])
+@pytest.mark.parametrize(
+    "clazz,kwargs,error_clazz",
+    [
+        (YapconfItem, {"name": "foo", "item_type": "INVALID_TYPE"}, YapconfItemError),
+        (
+            YapconfItem,
+            {"name": "foo", "choices": ["a"], "default": "b"},
+            YapconfValueError,
+        ),
+        (YapconfItem, {"name": "foo", "cli_short_name": "too_long"}, YapconfItemError),
+        (YapconfItem, {"name": "foo", "cli_short_name": "-"}, YapconfItemError),
+        (YapconfDictItem, {"name": "foo", "children": {}}, YapconfDictItemError),
+        (
+            YapconfDictItem,
+            {
+                "name": "foo",
+                "children": {"item1": YapconfItem("simple_item")},
+                "choices": [{"foo": "bar"}],
+            },
+            YapconfDictItemError,
+        ),
+        (
+            YapconfListItem,
+            {
+                "name": "foo",
+                "children": {
+                    "item1": YapconfItem("simple_item"),
+                    "item2": YapconfBoolItem("my_bool"),
+                },
+            },
+            YapconfListItemError,
+        ),
+    ],
+)
 def test_bad_specifications(clazz, kwargs, error_clazz):
     with pytest.raises(error_clazz):
         clazz(**kwargs)
@@ -110,96 +101,128 @@ def test_get_config_value_not_required(simple_item):
     assert simple_item.get_config_value({}) is None
 
 
-@pytest.mark.parametrize('default,config,expected', [
-    ('default', [('dict1', {})], 'default'),
-    ('default', [('dict1', {'foo': None})], 'default')
-])
+@pytest.mark.parametrize(
+    "default,config,expected",
+    [
+        ("default", [("dict1", {})], "default"),
+        ("default", [("dict1", {"foo": None})], "default"),
+    ],
+)
 def test_get_config_value_from_default(simple_item, default, config, expected):
     simple_item.default = default
     assert simple_item.get_config_value(config) == expected
 
 
 def test_get_config_value_from_override(simple_item):
-    simple_item.default = 'default'
-    assert simple_item.get_config_value([('dict-1', {'foo': 'bar'})]) == 'bar'
+    simple_item.default = "default"
+    assert simple_item.get_config_value([("dict-1", {"foo": "bar"})]) == "bar"
 
 
-@pytest.mark.parametrize('item_type,orig,expected', [
-    ('str', 123, '123'),
-    ('str', u'🐍', u'🐍'),
-    ('int', '123', 123),
-    ('long', '123', long('123')),
-    ('complex', '2j', 2j),
-])
+@pytest.mark.parametrize(
+    "item_type,orig,expected",
+    [
+        ("str", 123, "123"),
+        ("str", "🐍", "🐍"),
+        ("int", "123", 123),
+        ("long", "123", long("123")),
+        ("complex", "2j", 2j),
+    ],
+)
 def test_convert_config_value(simple_item, item_type, orig, expected):
     simple_item.item_type = item_type
-    assert simple_item.convert_config_value(orig, 'label') == expected
+    assert simple_item.convert_config_value(orig, "label") == expected
 
 
-@pytest.mark.parametrize('orig,expected', [
-    (True, True),
-    (False, False),
-    ('t', True),
-    ('TrUe', True),
-    ('y', True),
-    ('yes', True),
-    ('f', False),
-    ('False', False),
-    ('n', False),
-    ('no', False),
-    (1, True),
-    (0, False),
-    ('1', True),
-    ('0', False),
-])
+@pytest.mark.parametrize(
+    "orig,expected",
+    [
+        (True, True),
+        (False, False),
+        ("t", True),
+        ("TrUe", True),
+        ("y", True),
+        ("yes", True),
+        ("f", False),
+        ("False", False),
+        ("n", False),
+        ("no", False),
+        (1, True),
+        (0, False),
+        ("1", True),
+        ("0", False),
+    ],
+)
 def test_convert_bool_config_value(bool_item, orig, expected):
-    assert bool_item.convert_config_value(orig, 'label') == expected
+    assert bool_item.convert_config_value(orig, "label") == expected
 
 
-@pytest.mark.parametrize('item_type,value,exc_clazz', [
-    ('int', [], YapconfValueError),
-    ('INVALID_TYPE', 'value', YapconfItemError),
-    ('int', object, YapconfValueError),
-])
+@pytest.mark.parametrize(
+    "item_type,value,exc_clazz",
+    [
+        ("int", [], YapconfValueError),
+        ("INVALID_TYPE", "value", YapconfItemError),
+        ("int", object, YapconfValueError),
+    ],
+)
 def test_convert_config_value_error(simple_item, item_type, value, exc_clazz):
     simple_item.item_type = item_type
     with pytest.raises(exc_clazz):
-        simple_item.convert_config_value(value, 'label')
+        simple_item.convert_config_value(value, "label")
 
 
 def test_convert_config_value_invalid_bool(bool_item):
     with pytest.raises(YapconfValueError):
-        bool_item.convert_config_value('INVALID_VALUE', 'label')
+        bool_item.convert_config_value("INVALID_VALUE", "label")
 
 
-@pytest.mark.parametrize('env_name,alt_names, default,config,expected', [
-    ('FOO', [], None, {'FOO': 'foo_value', 'foo': 'should not be this'},
-     'foo_value'),
-    ('FOO', [], 'default', {'FOO': 'foo_value', 'foo': 'should not be this'},
-     'foo_value'),
-    ('FOO', [], 'default', {'FOO': None}, 'default'),
-    ('FOO', [], 'default', {'FOO': ''}, 'default'),
-    ('FOO', ['FOO_BACKUP'], None, {'FOO_BACKUP': 'foo_backup_value'},
-     'foo_backup_value')
-])
-def test_get_config_value_from_environment(simple_item, env_name, alt_names,
-                                           default, config, expected):
+@pytest.mark.parametrize(
+    "env_name,alt_names, default,config,expected",
+    [
+        (
+            "FOO",
+            [],
+            None,
+            {"FOO": "foo_value", "foo": "should not be this"},
+            "foo_value",
+        ),
+        (
+            "FOO",
+            [],
+            "default",
+            {"FOO": "foo_value", "foo": "should not be this"},
+            "foo_value",
+        ),
+        ("FOO", [], "default", {"FOO": None}, "default"),
+        ("FOO", [], "default", {"FOO": ""}, "default"),
+        (
+            "FOO",
+            ["FOO_BACKUP"],
+            None,
+            {"FOO_BACKUP": "foo_backup_value"},
+            "foo_backup_value",
+        ),
+    ],
+)
+def test_get_config_value_from_environment(
+    simple_item, env_name, alt_names, default, config, expected
+):
     simple_item.alt_env_names = alt_names
     simple_item.env_name = env_name
     simple_item.default = default
-    value = simple_item.get_config_value([('ENVIRONMENT', config)])
+    value = simple_item.get_config_value([("ENVIRONMENT", config)])
     assert value == expected
 
 
 def test_get_config_value_unformatted_env(unformatted_item):
     value = unformatted_item.get_config_value(
-        [('ENVIRONMENT', {unformatted_item.name: 'value'})])
-    assert value == 'value'
+        [("ENVIRONMENT", {unformatted_item.name: "value"})]
+    )
+    assert value == "value"
 
 
 def test_get_config_value_for_list(list_item):
-    value = list_item.get_config_value([('label', {'foos': ['foo1', 'foo2']})])
-    assert value == ['foo1', 'foo2']
+    value = list_item.get_config_value([("label", {"foos": ["foo1", "foo2"]})])
+    assert value == ["foo1", "foo2"]
 
 
 def test_get_config_value_for_list_not_there(list_item):
@@ -208,9 +231,9 @@ def test_get_config_value_for_list_not_there(list_item):
 
 
 def test_get_config_value_with_default(list_item):
-    list_item.default = ['foo1', 'foo2']
+    list_item.default = ["foo1", "foo2"]
     value = list_item.get_config_value({})
-    assert value == ['foo1', 'foo2']
+    assert value == ["foo1", "foo2"]
 
 
 def test_get_config_list_value_not_required(list_item):
@@ -220,84 +243,76 @@ def test_get_config_list_value_not_required(list_item):
 
 def test_get_config_value_not_a_list(list_item):
     with pytest.raises(YapconfValueError):
-        list_item.get_config_value([('label', {'foos': 123})])
+        list_item.get_config_value([("label", {"foos": 123})])
 
 
 def test_convert_config_value_not_a_list(list_item):
     with pytest.raises(YapconfValueError):
-        list_item.convert_config_value(123, 'label')
+        list_item.convert_config_value(123, "label")
 
 
 def test_get_config_ignore_environment(list_item):
-    list_item.env_name = 'FOOS'
+    list_item.env_name = "FOOS"
     value = list_item.get_config_value(
         [
-            ('ENVIRONMENT', {'FOOS': ['foo1', 'foo2']}),
-            ('label', {'foos': ['foo3', 'foo4']})
+            ("ENVIRONMENT", {"FOOS": ["foo1", "foo2"]}),
+            ("label", {"foos": ["foo3", "foo4"]}),
         ]
     )
-    assert value == ['foo3', 'foo4']
+    assert value == ["foo3", "foo4"]
 
 
 def test_dict_get_config_value(dict_item):
     value = dict_item.get_config_value(
-        [
-            ('label1', yapconf.flatten({'foo_dict': {'foo': 'bar'}}))
-        ]
+        [("label1", yapconf.flatten({"foo_dict": {"foo": "bar"}}))]
     )
-    assert value == {'foo': 'bar'}
+    assert value == {"foo": "bar"}
 
 
 def test_dict_get_config_value_ignore_environment(dict_item):
-    dict_item.env_name = 'FOO_DICT'
-    value = dict_item.get_config_value([
-        ('ENVIRONMENT', {'FOO_DICT': {'foo': 'bar'}}),
-        ('label1', yapconf.flatten({'foo_dict': {'foo': 'baz'}}))
-    ])
-    assert value == {'foo': 'baz'}
+    dict_item.env_name = "FOO_DICT"
+    value = dict_item.get_config_value(
+        [
+            ("ENVIRONMENT", {"FOO_DICT": {"foo": "bar"}}),
+            ("label1", yapconf.flatten({"foo_dict": {"foo": "baz"}})),
+        ]
+    )
+    assert value == {"foo": "baz"}
 
 
-@pytest.mark.parametrize('current_default,new_default,respect_flag,expected', [
-    (None, 'foo', False, 'foo'),
-    (None, None, False, None),
-    ('foo', None, False, 'foo'),
-    ('foo', None, True, None)
-])
-def test_update_default(simple_item, current_default, new_default,
-                        respect_flag, expected):
+@pytest.mark.parametrize(
+    "current_default,new_default,respect_flag,expected",
+    [
+        (None, "foo", False, "foo"),
+        (None, None, False, None),
+        ("foo", None, False, "foo"),
+        ("foo", None, True, None),
+    ],
+)
+def test_update_default(
+    simple_item, current_default, new_default, respect_flag, expected
+):
     simple_item.default = current_default
     simple_item.update_default(new_default, respect_none=respect_flag)
     assert simple_item.default == expected
 
 
-@pytest.mark.parametrize('type,required,default,short,name,args,expected', [
-    (
-        'str',
-        True,
-        'default_value',
-        None,
-        None,
-        ['--foo', 'foo_value'],
-        'foo_value'
-    ),
-    ('str', True, 'default_value', None, None, [], None),
-    ('str', False, None, None, None, [], None),
-    ('str', True, None, 'f', None, ['-f', 'foo_value'], 'foo_value'),
-    ('str', True, None, 'f', 'alt', ['--alt', 'foo_value'], 'foo_value'),
-    ('int', True, None, 'f', None, ['-f', '1'], 1),
-    ('long', True, None, 'f', None, ['-f', '1'], long(1)),
-    ('float', True, None, 'f', None, ['-f', '1.23'], 1.23),
-    ('complex', True, None, 'f', None, ['-f', '2j'], 2j),
-])
+@pytest.mark.parametrize(
+    "type,required,default,short,name,args,expected",
+    [
+        ("str", True, "default_value", None, None, ["--foo", "foo_value"], "foo_value"),
+        ("str", True, "default_value", None, None, [], None),
+        ("str", False, None, None, None, [], None),
+        ("str", True, None, "f", None, ["-f", "foo_value"], "foo_value"),
+        ("str", True, None, "f", "alt", ["--alt", "foo_value"], "foo_value"),
+        ("int", True, None, "f", None, ["-f", "1"], 1),
+        ("long", True, None, "f", None, ["-f", "1"], long(1)),
+        ("float", True, None, "f", None, ["-f", "1.23"], 1.23),
+        ("complex", True, None, "f", None, ["-f", "2j"], 2j),
+    ],
+)
 def test_add_argument(
-    simple_item,
-    type,
-    required,
-    default,
-    short,
-    name,
-    args,
-    expected
+    simple_item, type, required, default, short, name, args, expected
 ):
     simple_item.item_type = type
     simple_item.required = required
@@ -310,21 +325,22 @@ def test_add_argument(
     assert values[simple_item.name] == expected
 
 
-@pytest.mark.parametrize('default,short_name,cli_name,args,expected', [
-    (True, None, None, ['--no-my-bool'], False),
-    (False, None, None, ['--my-bool'], True),
-    (None, None, None, ['--my-bool'], True),
-    (None, None, None, ['--no-my-bool'], False),
-    (None, None, 'alt', ['--no-alt'], False),
-    (None, None, 'alt', ['--alt'], True),
-    (None, 'b', None, ['--no-b'], False),
-    (None, 'b', None, ['--b'], True),
-    (True, None, None, [], None),
-    (False, None, None, [], None),
-])
-def test_add_bool_argument(
-    bool_item, default, short_name, cli_name, args, expected
-):
+@pytest.mark.parametrize(
+    "default,short_name,cli_name,args,expected",
+    [
+        (True, None, None, ["--no-my-bool"], False),
+        (False, None, None, ["--my-bool"], True),
+        (None, None, None, ["--my-bool"], True),
+        (None, None, None, ["--no-my-bool"], False),
+        (None, None, "alt", ["--no-alt"], False),
+        (None, None, "alt", ["--alt"], True),
+        (None, "b", None, ["--no-b"], False),
+        (None, "b", None, ["--b"], True),
+        (True, None, None, [], None),
+        (False, None, None, [], None),
+    ],
+)
+def test_add_bool_argument(bool_item, default, short_name, cli_name, args, expected):
     bool_item.default = default
     bool_item.cli_short_name = short_name
     bool_item.cli_name = cli_name
@@ -337,32 +353,33 @@ def test_add_bool_argument(
 def test_add_argument_unformatted(unformatted_item):
     parser = ArgumentParser()
     unformatted_item.add_argument(parser)
-    args = ['--%s' % unformatted_item.name, 'value']
+    args = ["--%s" % unformatted_item.name, "value"]
     values = vars(parser.parse_args(args))
-    assert values[unformatted_item.name] == 'value'
+    assert values[unformatted_item.name] == "value"
 
 
 def test_add_argument_unformatted_bool(unformatted_bool_item):
     parser = ArgumentParser()
     unformatted_bool_item.add_argument(parser)
-    args = ['--no-%s' % unformatted_bool_item.name]
+    args = ["--no-%s" % unformatted_bool_item.name]
     values = vars(parser.parse_args(args))
     assert values[unformatted_bool_item.name] is False
 
 
-@pytest.mark.parametrize('list_default,child_default,args,expected', [
-    (None, True, ['--my-bool', '--no-my-bool'], [True, False]),
-    (None, False, ['--no-my-bool', '--my-bool'], [False, True]),
-    ([True, False], False, [], None),
-    ([True, False], None, [], None),
-    ([True, False], None, ['--my-bool'], [True]),
-    ([True, False], None, ['--no-my-bool'], [False]),
-])
-def test_add_list_boolean_arguments(bool_list_item,
-                                    list_default,
-                                    child_default,
-                                    args,
-                                    expected):
+@pytest.mark.parametrize(
+    "list_default,child_default,args,expected",
+    [
+        (None, True, ["--my-bool", "--no-my-bool"], [True, False]),
+        (None, False, ["--no-my-bool", "--my-bool"], [False, True]),
+        ([True, False], False, [], None),
+        ([True, False], None, [], None),
+        ([True, False], None, ["--my-bool"], [True]),
+        ([True, False], None, ["--no-my-bool"], [False]),
+    ],
+)
+def test_add_list_boolean_arguments(
+    bool_list_item, list_default, child_default, args, expected
+):
     bool_list_item.default = list_default
     bool_list_item.child.default = child_default
     parser = ArgumentParser()
@@ -372,18 +389,17 @@ def test_add_list_boolean_arguments(bool_list_item,
     assert values[bool_list_item.name] == expected
 
 
-@pytest.mark.parametrize('list_default,child_default,args,expected', [
-    (None, None, ['--foo', 'foo1', '--foo', 'foo2'], ['foo1', 'foo2']),
-    (None, "foo", ['--foo', 'foo1', '--foo', 'foo2'], ['foo1', 'foo2']),
-    (['foo1', 'foo2'], 'foo', [], None),
-    ([], 'foo', [], None),
-    (['foo1', 'foo2'], None, ['--foo', 'foo'], ['foo']),
-])
-def test_add_list_arguments(list_item,
-                            list_default,
-                            child_default,
-                            args,
-                            expected):
+@pytest.mark.parametrize(
+    "list_default,child_default,args,expected",
+    [
+        (None, None, ["--foo", "foo1", "--foo", "foo2"], ["foo1", "foo2"]),
+        (None, "foo", ["--foo", "foo1", "--foo", "foo2"], ["foo1", "foo2"]),
+        (["foo1", "foo2"], "foo", [], None),
+        ([], "foo", [], None),
+        (["foo1", "foo2"], None, ["--foo", "foo"], ["foo"]),
+    ],
+)
+def test_add_list_arguments(list_item, list_default, child_default, args, expected):
     list_item.default = list_default
     list_item.child.default = child_default
     parser = ArgumentParser()
@@ -392,29 +408,37 @@ def test_add_list_arguments(list_item,
     assert values[list_item.name] == expected
 
 
-@pytest.mark.parametrize('dict_default,args,expected', [
-    (
-        None,
-        ['--db-name', 'db_name', '--db-port', '123', '--db-verbose',
-         '--db-users', 'user1', '--db-users', 'user2',
-         '--db-log-level', 'INFO',
-         '--db-log-file', '/path/to/file'],
-        {
-            'name': 'db_name',
-            'port': 123,
-            'verbose': True,
-            'users': ['user1', 'user2'],
-            'log': {
-                'level': 'INFO',
-                'file': '/path/to/file'
-            }
-        }
-    )
-])
-def test_basic_dict_add_argument(db_item,
-                                 dict_default,
-                                 args,
-                                 expected):
+@pytest.mark.parametrize(
+    "dict_default,args,expected",
+    [
+        (
+            None,
+            [
+                "--db-name",
+                "db_name",
+                "--db-port",
+                "123",
+                "--db-verbose",
+                "--db-users",
+                "user1",
+                "--db-users",
+                "user2",
+                "--db-log-level",
+                "INFO",
+                "--db-log-file",
+                "/path/to/file",
+            ],
+            {
+                "name": "db_name",
+                "port": 123,
+                "verbose": True,
+                "users": ["user1", "user2"],
+                "log": {"level": "INFO", "file": "/path/to/file"},
+            },
+        )
+    ],
+)
+def test_basic_dict_add_argument(db_item, dict_default, args, expected):
     db_item.default = dict_default
     parser = ArgumentParser()
     db_item.add_argument(parser)
@@ -426,142 +450,128 @@ def test_basic_dict_get_config_value_from_env(db_item):
     value = db_item.get_config_value(
         [
             (
-                'ENVIRONMENT',
-                {
-                    'ALT_NAME': 'db_name',
-                    'DB_PORT': '1234',
-                    'DB_VERBOSE': 'True'
-                }
+                "ENVIRONMENT",
+                {"ALT_NAME": "db_name", "DB_PORT": "1234", "DB_VERBOSE": "True"},
             ),
             (
-                'dict1',
-                yapconf.flatten({
-                    'db': {
-                        'users': ['user1', 'user2'],
-                        'log': {'level': 'INFO', 'file': '/some/file'}
+                "dict1",
+                yapconf.flatten(
+                    {
+                        "db": {
+                            "users": ["user1", "user2"],
+                            "log": {"level": "INFO", "file": "/some/file"},
+                        }
                     }
-                })
-            )
+                ),
+            ),
         ]
     )
-    assert value['name'] == 'db_name'
-    assert value['port'] == 1234
+    assert value["name"] == "db_name"
+    assert value["port"] == 1234
 
 
-@pytest.mark.parametrize('item,config', [
-    (
-        YapconfItem("foo", choices=['a', 'b', 'c']),
-        {'foo': 'd'}
-    ),
-    (
-        YapconfListItem("foos",
-                        children={
-                            'foo': YapconfItem('foo',
-                                               choices=['a', 'b', 'c'])
-                        }),
-        {'foos': ['d']},
-    ),
-    (
-        YapconfListItem("foos",
-                        choices=[['a', 'a'], ['a', 'b'], ['c']],
-                        children={
-                            'foo': YapconfItem('foo',
-                                               choices=['a', 'b', 'c'])
-                        }),
-        {'foos': ['a']}
-    ),
-    (
-        YapconfDictItem("foo_dict",
-                        children={
-                            "foo": YapconfItem('foo',
-                                               choices=['bar', 'baz'],
-                                               prefix='foo_dict')
-                        }),
-        yapconf.flatten({'foo_dict': {'foo': 'invalid'}})
-    ),
-])
+@pytest.mark.parametrize(
+    "item,config",
+    [
+        (YapconfItem("foo", choices=["a", "b", "c"]), {"foo": "d"}),
+        (
+            YapconfListItem(
+                "foos", children={"foo": YapconfItem("foo", choices=["a", "b", "c"])}
+            ),
+            {"foos": ["d"]},
+        ),
+        (
+            YapconfListItem(
+                "foos",
+                choices=[["a", "a"], ["a", "b"], ["c"]],
+                children={"foo": YapconfItem("foo", choices=["a", "b", "c"])},
+            ),
+            {"foos": ["a"]},
+        ),
+        (
+            YapconfDictItem(
+                "foo_dict",
+                children={
+                    "foo": YapconfItem("foo", choices=["bar", "baz"], prefix="foo_dict")
+                },
+            ),
+            yapconf.flatten({"foo_dict": {"foo": "invalid"}}),
+        ),
+    ],
+)
 def test_choices(item, config):
     with pytest.raises(YapconfValueError):
-        item.get_config_value([('test', config)])
+        item.get_config_value([("test", config)])
 
 
 def test_from_spec_list_fq_names():
     spec = {
-        'list1': {
-            'type': 'list',
-            'required': True,
-            'items': {
-                'list_item': {
-                    'type': 'str',
-                    'required': True
-                },
+        "list1": {
+            "type": "list",
+            "required": True,
+            "items": {
+                "list_item": {"type": "str", "required": True},
             },
         },
-        'list2': {
-            'type': 'list',
-            'required': True,
-            'items': {
-                'list_dict_item': {
-                    'type': 'dict',
-                    'required': True,
-                    'items': {
-                        'foo': {},
-                        'bar': {},
+        "list2": {
+            "type": "list",
+            "required": True,
+            "items": {
+                "list_dict_item": {
+                    "type": "dict",
+                    "required": True,
+                    "items": {
+                        "foo": {},
+                        "bar": {},
                     },
                 },
             },
         },
     }
     items = from_specification(spec)
-    assert items['list1'].fq_name == 'list1'
-    assert items['list1'].children['list1'].fq_name == 'list1'
-    assert items['list2'].children['list2'].fq_name == 'list2'
-    assert (
-        items['list2'].children['list2'].children['foo'].fq_name ==
-        'list2.foo'
-    )
-    assert (
-        items['list2'].children['list2'].children['bar'].fq_name ==
-        'list2.bar'
-    )
+    assert items["list1"].fq_name == "list1"
+    assert items["list1"].children["list1"].fq_name == "list1"
+    assert items["list2"].children["list2"].fq_name == "list2"
+    assert items["list2"].children["list2"].children["foo"].fq_name == "list2.foo"
+    assert items["list2"].children["list2"].children["bar"].fq_name == "list2.bar"
 
 
 def test_from_specification_check_fq_names():
     spec = {
-        'foo': {
-            'type': 'dict',
-            'required': True,
-            'items': {
-                'bar': {
-                    'type': 'dict',
-                    'required': True,
-                    'items': {
-                        'baz': {
-                            'type': 'str', 'required': True,
+        "foo": {
+            "type": "dict",
+            "required": True,
+            "items": {
+                "bar": {
+                    "type": "dict",
+                    "required": True,
+                    "items": {
+                        "baz": {
+                            "type": "str",
+                            "required": True,
                         },
                     },
                 },
-                'bat': {
-                    'type': 'bool',
-                }
+                "bat": {
+                    "type": "bool",
+                },
             },
         },
     }
     items = from_specification(spec)
-    assert items['foo'].fq_name == 'foo'
-    assert items['foo'].children['bar'].fq_name == 'foo.bar'
-    assert (
-        items['foo'].children['bar'].children['baz'].fq_name == 'foo.bar.baz'
-    )
-    assert items['foo'].children['bat'].fq_name == 'foo.bat'
+    assert items["foo"].fq_name == "foo"
+    assert items["foo"].children["bar"].fq_name == "foo.bar"
+    assert items["foo"].children["bar"].children["baz"].fq_name == "foo.bar.baz"
+    assert items["foo"].children["bat"].fq_name == "foo.bat"
 
 
 def test_invalid_value():
     def always_invalid(value):
         return False
-    item = from_specification({'foo': {'validator': always_invalid}})['foo']
+
+    item = from_specification({"foo": {"validator": always_invalid}})["foo"]
     with pytest.raises(YapconfValueError):
-        item.get_config_value([('label', {'foo': 'bar'})])
+        item.get_config_value([("label", {"foo": "bar"})])
 
 
 def test_filter():
@@ -604,15 +614,11 @@ def test_dict_filter(db_item):
     assert len(actual.children["log"].children) == 1
     assert "level" in actual.children["log"].children
 
-    actual = db_item.apply_filter(
-        exclude=["db.log"]
-    )
+    actual = db_item.apply_filter(exclude=["db.log"])
     assert len(actual.children) == 4
     assert "log" not in actual.children
 
-    actual = db_item.apply_filter(
-        exclude=["db.log.file"]
-    )
+    actual = db_item.apply_filter(exclude=["db.log.file"])
     assert len(actual.children) == 5
     assert "log" in actual.children
     assert "file" not in actual.children["log"].children

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -294,15 +294,18 @@ def test_migrate_config_file_does_not_exist_create(basic_spec):
 @patch('os.path.isfile', Mock(return_value=False))
 def test_migrate_config_file_create_yaml(basic_spec):
     open_path = 'yapconf.open'
-    with patch('yapconf.yaml.safe_dump') as dump_mock:
+    with patch('yapconf.yaml.dump') as dump_mock:
         with patch(open_path, mock_open()) as mock_file:
             new_config = basic_spec.migrate_config_file(
                 '/path/to/file', create=True, output_file_type='yaml')
-            dump_mock.assert_called_with(
+            if type(yapconf.yaml).__name__== "YAML":
+                dump_mock.assert_called_with(
+                    {"foo": None},
+                    mock_file())
+            else:
+                dump_mock.assert_called_with(
                 {"foo": None},
-                mock_file(),
-                default_flow_style=False,
-                encoding='utf-8')
+                mock_file(), default_flow_style=False, encoding='utf-8')
 
     assert new_config == {"foo": None}
 

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -7,9 +7,10 @@ import time
 from argparse import ArgumentParser
 
 import pytest
-import yaml
+import yaml as legacy_yaml
 from mock import Mock, mock_open, patch
 from pytest_lazy_fixtures import lf
+from ruamel import yaml
 
 import yapconf
 from yapconf.exceptions import (YapconfItemNotFound, YapconfLoadError,
@@ -593,7 +594,7 @@ def test_load_environment(basic_spec):
 @pytest.mark.usefixtures('simple_spec')
 @pytest.mark.parametrize('key,config_type,formatter', [
     (None, None, None),
-    ('file.yaml', 'yaml', yaml.dump),
+    ('file.yaml', 'yaml', legacy_yaml.dump),
     ('file.json', 'json', json.dumps),
 ])
 def test_load_kubernetes(simple_spec, key, config_type, formatter):

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -7,9 +7,9 @@ import time
 from argparse import ArgumentParser
 
 import pytest
+import yaml
 from mock import Mock, mock_open, patch
 from pytest_lazy_fixtures import lf
-from ruamel import yaml
 
 import yapconf
 from yapconf.exceptions import (YapconfItemNotFound, YapconfLoadError,

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -33,117 +33,118 @@ def setup_function(function):
 def teardown_function(function):
     os.environ = original_env
     yapconf.yaml = original_yaml
-    real_world_path = os.path.join(current_dir, 'files', 'real_world')
-    tmp_path = os.path.join(real_world_path, 'tmp')
+    real_world_path = os.path.join(current_dir, "files", "real_world")
+    tmp_path = os.path.join(real_world_path, "tmp")
 
-    json_file = os.path.join(real_world_path, 'config_to_change.json')
-    yaml_file = os.path.join(real_world_path, 'config_to_change.yaml')
+    json_file = os.path.join(real_world_path, "config_to_change.json")
+    yaml_file = os.path.join(real_world_path, "config_to_change.yaml")
     original_data = {
-        'database': {
-            'host': '1.2.3.4',
-            'name': 'myapp_prod',
-            'port': 3306,
-            'verbose': False,
+        "database": {
+            "host": "1.2.3.4",
+            "name": "myapp_prod",
+            "port": 3306,
+            "verbose": False,
         },
-        'emoji': u'💩',
-        'file': '/path/to/file.yaml',
-        'ssl': {
-            'private_key': 'blah',
-            'public_key': 'blah',
+        "emoji": "💩",
+        "file": "/path/to/file.yaml",
+        "ssl": {
+            "private_key": "blah",
+            "public_key": "blah",
         },
-        'web_port': 443,
+        "web_port": 443,
     }
 
-    yapconf.dump_data(original_data, json_file, file_type='json')
-    yapconf.dump_data(original_data, yaml_file, file_type='yaml')
+    yapconf.dump_data(original_data, json_file, file_type="json")
+    yapconf.dump_data(original_data, yaml_file, file_type="yaml")
     if os.path.exists(tmp_path):
         os.remove(tmp_path)
 
 
 def test_simple_load_config(simple_spec):
-    config = simple_spec.load_config({'my_string': 'some value',
-                                      'my_int': 123,
-                                      'my_long': long(123),
-                                      'my_float': 123.45,
-                                      'my_bool': False,
-                                      'my_complex': 2j,
-                                      })
-    assert config['my_string'] == 'some value'
-    assert config['my_int'] == 123
-    assert config['my_long'] == long(123)
-    assert config['my_float'] == 123.45
-    assert not config['my_bool']
-    assert config['my_complex'] == 2j
+    config = simple_spec.load_config(
+        {
+            "my_string": "some value",
+            "my_int": 123,
+            "my_long": long(123),
+            "my_float": 123.45,
+            "my_bool": False,
+            "my_complex": 2j,
+        }
+    )
+    assert config["my_string"] == "some value"
+    assert config["my_int"] == 123
+    assert config["my_long"] == long(123)
+    assert config["my_float"] == 123.45
+    assert not config["my_bool"]
+    assert config["my_complex"] == 2j
 
 
 def test_load_list_config(spec_with_lists):
-    config = spec_with_lists.load_config({
-        'simple_list': ['a', 'b', 'c'],
-        'top_list': [[1, 2, 3], [4, 5, 6]],
-        'list_of_dictionaries': [
-            {'foo': 'foo_value', 'bar': 'bar_value'},
-            {'foo': 'foo_value2', 'bar': 'bar_value2'}
-        ]
-    })
+    config = spec_with_lists.load_config(
+        {
+            "simple_list": ["a", "b", "c"],
+            "top_list": [[1, 2, 3], [4, 5, 6]],
+            "list_of_dictionaries": [
+                {"foo": "foo_value", "bar": "bar_value"},
+                {"foo": "foo_value2", "bar": "bar_value2"},
+            ],
+        }
+    )
 
-    assert len(config['simple_list']) == 3
-    assert 'a' in config['simple_list']
-    assert 'b' in config['simple_list']
-    assert 'c' in config['simple_list']
+    assert len(config["simple_list"]) == 3
+    assert "a" in config["simple_list"]
+    assert "b" in config["simple_list"]
+    assert "c" in config["simple_list"]
 
-    assert len(config['top_list']) == 2
-    assert len(config['top_list'][0]) == 3
-    assert len(config['top_list'][1]) == 3
+    assert len(config["top_list"]) == 2
+    assert len(config["top_list"][0]) == 3
+    assert len(config["top_list"][1]) == 3
 
-    assert len(config['list_of_dictionaries']) == 2
-    assert 'foo' in config['list_of_dictionaries'][0]
-    assert 'bar' in config['list_of_dictionaries'][0]
-    assert 'foo' in config['list_of_dictionaries'][1]
-    assert 'bar' in config['list_of_dictionaries'][1]
+    assert len(config["list_of_dictionaries"]) == 2
+    assert "foo" in config["list_of_dictionaries"][0]
+    assert "bar" in config["list_of_dictionaries"][0]
+    assert "foo" in config["list_of_dictionaries"][1]
+    assert "bar" in config["list_of_dictionaries"][1]
 
 
 def test_nested_load_config(spec_with_dicts):
     config = spec_with_dicts.load_config(
         {
-            'database': {
-                'name': 'dbname',
-                'host': 'dbhost',
-                'port': 1234
-            },
-            'foo': {
-                'bar': {'baz': 'baz_value'},
-                'bat': True
-            }
+            "database": {"name": "dbname", "host": "dbhost", "port": 1234},
+            "foo": {"bar": {"baz": "baz_value"}, "bat": True},
         }
     )
-    assert config['database']['name'] == 'dbname'
-    assert config['database']['host'] == 'dbhost'
-    assert config['database']['port'] == 1234
+    assert config["database"]["name"] == "dbname"
+    assert config["database"]["host"] == "dbhost"
+    assert config["database"]["port"] == 1234
 
-    assert config['foo']['bar']['baz'] == 'baz_value'
-    assert config['foo']['bat']
+    assert config["foo"]["bar"]["baz"] == "baz_value"
+    assert config["foo"]["bat"]
 
 
-@pytest.mark.parametrize('kwargs,expected', [
-    ({"bootstrap": True}, {"file": "/path/to/file.yaml"}),
-    (
-        {"exclude_bootstrap": True},
-        {
-            "web_port": 443,
-            "ssl": {
-                "private_key": "/path/to/private.key",
-                "public_key": "/path/to/public.crt",
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"bootstrap": True}, {"file": "/path/to/file.yaml"}),
+        (
+            {"exclude_bootstrap": True},
+            {
+                "web_port": 443,
+                "ssl": {
+                    "private_key": "/path/to/private.key",
+                    "public_key": "/path/to/public.crt",
+                },
+                "database": {
+                    "name": "myapp_prod",
+                    "host": "1.2.3.4",
+                    "port": 3306,
+                    "verbose": False,
+                },
+                "emoji": "💩",
             },
-            "database": {
-                "name": "myapp_prod",
-                "host": "1.2.3.4",
-                "port": 3306,
-                "verbose": False,
-            },
-            "emoji": u"💩",
-        }
-    ),
-])
+        ),
+    ],
+)
 def test_load_with_kwargs(real_world_spec, current_config, kwargs, expected):
     config = real_world_spec.load_filtered_config(current_config, **kwargs)
     assert config == expected
@@ -151,15 +152,18 @@ def test_load_with_kwargs(real_world_spec, current_config, kwargs, expected):
 
 def test_spec_bad_file_type():
     with pytest.raises(YapconfSpecError):
-        YapconfSpec({}, file_type='INVALID')
+        YapconfSpec({}, file_type="INVALID")
 
 
-@pytest.mark.parametrize('bad_data', [
-    (['THIS SHOULD BE A DICT']),
-    ({'name': 'THIS SHOULD BE A DICT'}),
-    ({'name': {'type': 'str', 'items': {'name2': {'type': 'str'}}}}),
-    ({'name': {'type': 'list', 'error': 'it has not items entry'}}),
-])
+@pytest.mark.parametrize(
+    "bad_data",
+    [
+        (["THIS SHOULD BE A DICT"]),
+        ({"name": "THIS SHOULD BE A DICT"}),
+        ({"name": {"type": "str", "items": {"name2": {"type": "str"}}}}),
+        ({"name": {"type": "list", "error": "it has not items entry"}}),
+    ],
+)
 def test_invalid_specification(bad_data):
     with pytest.raises(YapconfSpecError):
         YapconfSpec(bad_data)
@@ -167,55 +171,62 @@ def test_invalid_specification(bad_data):
 
 def test_load_config_fallbacks(simple_spec):
     config = simple_spec.load_config(
-        {'my_string': 'some value'},
-        {'my_int': 123},
-        {'my_long': long(123)},
-        {'my_float': 123.45},
-        {'my_bool': False},
-        {'my_complex': 2j}
+        {"my_string": "some value"},
+        {"my_int": 123},
+        {"my_long": long(123)},
+        {"my_float": 123.45},
+        {"my_bool": False},
+        {"my_complex": 2j},
     )
-    assert config['my_string'] == 'some value'
-    assert config['my_int'] == 123
-    assert config['my_long'] == long(123)
-    assert config['my_float'] == 123.45
-    assert not config['my_bool']
-    assert config['my_complex'] == 2j
+    assert config["my_string"] == "some value"
+    assert config["my_int"] == 123
+    assert config["my_long"] == long(123)
+    assert config["my_float"] == 123.45
+    assert not config["my_bool"]
+    assert config["my_complex"] == 2j
 
 
-@pytest.mark.parametrize('file_type,file_data,overrides,expected_value', [
-    ('json', '{"foo": {"type": "str"}}', {"foo": "bar"}, {"foo": "bar"}),
-    ('yaml',
-     '''foo:
-        type: str''',
-     {'foo': 'bar'},
-     {'foo': 'bar'})
-])
-def test_load_specification_from_file(file_type, file_data,
-                                      overrides, expected_value):
-    open_path = 'yapconf.open'
+@pytest.mark.parametrize(
+    "file_type,file_data,overrides,expected_value",
+    [
+        ("json", '{"foo": {"type": "str"}}', {"foo": "bar"}, {"foo": "bar"}),
+        (
+            "yaml",
+            """foo:
+        type: str""",
+            {"foo": "bar"},
+            {"foo": "bar"},
+        ),
+    ],
+)
+def test_load_specification_from_file(file_type, file_data, overrides, expected_value):
+    open_path = "yapconf.open"
     with patch(open_path, mock_open(read_data=file_data)):
-        spec = YapconfSpec('/path/to/specification', file_type=file_type)
+        spec = YapconfSpec("/path/to/specification", file_type=file_type)
         assert spec.load_config(overrides) == expected_value
 
 
 def test_load_bad_specification_from_file():
-    open_path = 'yapconf.open'
+    open_path = "yapconf.open"
     with patch(open_path, mock_open(read_data="[]")):
         with pytest.raises(YapconfSpecError):
-            YapconfSpec('/path/to/bad/spec', file_type='json')
+            YapconfSpec("/path/to/bad/spec", file_type="json")
 
 
 def test_load_from_env(basic_spec):
-    os.environ['FOO'] = 'foo_value'
-    config = basic_spec.load_config('ENVIRONMENT')
-    assert config['foo'] == 'foo_value'
+    os.environ["FOO"] = "foo_value"
+    config = basic_spec.load_config("ENVIRONMENT")
+    assert config["foo"] == "foo_value"
 
 
-@pytest.mark.parametrize('override', [
-    ("Need another item",),
-    ("label", "file", "invalid_file_type"),
-    (["THIS SHOULD BE A DICT"])
-])
+@pytest.mark.parametrize(
+    "override",
+    [
+        ("Need another item",),
+        ("label", "file", "invalid_file_type"),
+        (["THIS SHOULD BE A DICT"]),
+    ],
+)
 def test_load_config_invalid_override(basic_spec, override):
     with pytest.raises(YapconfLoadError):
         basic_spec.load_config(override)
@@ -224,163 +235,161 @@ def test_load_config_invalid_override(basic_spec, override):
 def test_load_config_yaml_not_supported(basic_spec):
     yapconf.yaml = None
     with pytest.raises(YapconfSourceError):
-        basic_spec.load_config(('label', 'path/to/file', 'yaml'))
+        basic_spec.load_config(("label", "path/to/file", "yaml"))
 
 
 def test_load_config_nested_from_environment(spec_with_dicts):
-    os.environ['FOO_BAR_BAZ'] = 'baz_value'
+    os.environ["FOO_BAR_BAZ"] = "baz_value"
     config = spec_with_dicts.load_config(
         {
-            'database': {'name': 'dbname', 'host': 'dbhost', 'port': 1234},
-            'foo': {'bat': True}
+            "database": {"name": "dbname", "host": "dbhost", "port": 1234},
+            "foo": {"bat": True},
         },
-        'ENVIRONMENT'
+        "ENVIRONMENT",
     )
     value = spec_with_dicts.load_config(config)
-    assert value['foo']['bar']['baz'] == 'baz_value'
+    assert value["foo"]["bar"]["baz"] == "baz_value"
 
 
 def test_load_config_multi_part_dictionary(spec_with_dicts):
     config = spec_with_dicts.load_config(
-        {'database': {'name': 'dbname'}},
-        {'database': {'host': 'dbhost'}},
-        {'database': {'port': 1234}},
-        {'foo': {'bar': {'baz': 'baz_value'}, 'bat': True}}
+        {"database": {"name": "dbname"}},
+        {"database": {"host": "dbhost"}},
+        {"database": {"port": 1234}},
+        {"foo": {"bar": {"baz": "baz_value"}, "bat": True}},
     )
     value = spec_with_dicts.load_config(config)
-    assert value['database'] == {'name': 'dbname',
-                                 'host': 'dbhost',
-                                 'port': 1234}
+    assert value["database"] == {"name": "dbname", "host": "dbhost", "port": 1234}
 
 
-@patch('os.path.isfile', Mock(return_value=True))
+@patch("os.path.isfile", Mock(return_value=True))
 def test_migrate_config_file():
-    spec = YapconfSpec({'foo': {'bootstrap': True}})
-    with patch('yapconf.open', mock_open(read_data='{}')):
+    spec = YapconfSpec({"foo": {"bootstrap": True}})
+    with patch("yapconf.open", mock_open(read_data="{}")):
         config = spec.migrate_config_file(
-            '/path/to/file',
-            create=False,
-            include_bootstrap=False
+            "/path/to/file", create=False, include_bootstrap=False
         )
     assert config == {}
 
 
-@patch('os.path.isfile', Mock(return_value=True))
+@patch("os.path.isfile", Mock(return_value=True))
 def test_migrate_config_file_no_changes(basic_spec):
-    open_path = 'yapconf.open'
+    open_path = "yapconf.open"
     current_config = '{"foo": "bar"}'
     with patch(open_path, mock_open(read_data=current_config)):
-        new_config = basic_spec.migrate_config_file('/path/to/file',
-                                                    create=False)
+        new_config = basic_spec.migrate_config_file("/path/to/file", create=False)
 
     assert new_config == {"foo": "bar"}
 
 
-@patch('os.path.isfile', Mock(return_value=False))
+@patch("os.path.isfile", Mock(return_value=False))
 def test_migrate_config_file_does_not_exist_do_not_create(basic_spec):
     with pytest.raises(YapconfLoadError):
-        basic_spec.migrate_config_file('/path/to/file', create=False)
+        basic_spec.migrate_config_file("/path/to/file", create=False)
 
 
-@patch('os.path.isfile', Mock(return_value=False))
+@patch("os.path.isfile", Mock(return_value=False))
 def test_migrate_config_file_does_not_exist_create(basic_spec):
-    open_path = 'yapconf.open'
+    open_path = "yapconf.open"
     with patch(open_path, mock_open()):
-        new_config = basic_spec.migrate_config_file('/path/to/file',
-                                                    create=True)
+        new_config = basic_spec.migrate_config_file("/path/to/file", create=True)
 
     assert new_config == {"foo": None}
 
 
-@patch('os.path.isfile', Mock(return_value=False))
+@patch("os.path.isfile", Mock(return_value=False))
 def test_migrate_config_file_create_yaml(basic_spec):
-    open_path = 'yapconf.open'
-    with patch('yapconf.yaml.dump') as dump_mock:
+    open_path = "yapconf.open"
+    with patch("yapconf.yaml.dump") as dump_mock:
         with patch(open_path, mock_open()) as mock_file:
             new_config = basic_spec.migrate_config_file(
-                '/path/to/file', create=True, output_file_type='yaml')
-            if type(yapconf.yaml).__name__== "YAML":
-                dump_mock.assert_called_with(
-                    {"foo": None},
-                    mock_file())
+                "/path/to/file", create=True, output_file_type="yaml"
+            )
+            if type(yapconf.yaml).__name__ == "YAML":
+                dump_mock.assert_called_with({"foo": None}, mock_file())
             else:
                 dump_mock.assert_called_with(
-                {"foo": None},
-                mock_file(), default_flow_style=False, encoding='utf-8')
+                    {"foo": None},
+                    mock_file(),
+                    default_flow_style=False,
+                    encoding="utf-8",
+                )
 
     assert new_config == {"foo": None}
 
 
-@patch('os.path.isfile', Mock(return_value=True))
+@patch("os.path.isfile", Mock(return_value=True))
 def test_migrate_config_file_always_update(basic_spec):
-    open_path = 'yapconf.open'
+    open_path = "yapconf.open"
     current_config = '{"foo": "bar"}'
     with patch(open_path, mock_open(read_data=current_config)):
-        new_config = basic_spec.migrate_config_file('/path/to/file',
-                                                    create=False,
-                                                    always_update=True)
+        new_config = basic_spec.migrate_config_file(
+            "/path/to/file", create=False, always_update=True
+        )
 
     assert new_config == {"foo": None}
 
 
-@patch('os.path.isfile', Mock(return_value=True))
+@patch("os.path.isfile", Mock(return_value=True))
 def test_migrate_config_file_update_previous_default():
-    spec = YapconfSpec({'foo': {'default': 'baz',
-                                'previous_defaults': ['bar']}})
-    open_path = 'yapconf.open'
+    spec = YapconfSpec({"foo": {"default": "baz", "previous_defaults": ["bar"]}})
+    open_path = "yapconf.open"
     current_config = '{"foo": "bar"}'
     with patch(open_path, mock_open(read_data=current_config)):
-        new_config = spec.migrate_config_file('/path/to/file',
-                                              create=False,
-                                              update_defaults=True)
-    assert new_config == {'foo': 'baz'}
+        new_config = spec.migrate_config_file(
+            "/path/to/file", create=False, update_defaults=True
+        )
+    assert new_config == {"foo": "baz"}
 
 
 def test_migrate_config_no_mock(tmpdir, basic_spec):
-    new_path = tmpdir.join('config.json')
+    new_path = tmpdir.join("config.json")
     with pytest.raises(YapconfLoadError):
         basic_spec.migrate_config_file(str(new_path), create=False)
 
 
 def test_migrate_config_no_mock_create_file(tmpdir, basic_spec):
-    new_path = tmpdir.join('config.json')
+    new_path = tmpdir.join("config.json")
     basic_spec.migrate_config_file(str(new_path), create=True)
     assert json.load(new_path) == {"foo": None}
 
 
-@pytest.mark.usefixtures('basic_spec')
-@pytest.mark.parametrize('config', [
-    ({'foo': None}),
-    ({'foo': 'bar'}),
-    ({'foo': u'bar'}),
-    ({'foo': u'\U0001F4A9'}),
-    ({'foo': u'💩'}),
-    ({u'\U0001F4A9': 'foo'}),
-    ({u'💩': 'foo'}),
-    ({u'💩': u'💩'}),
-])
+@pytest.mark.usefixtures("basic_spec")
+@pytest.mark.parametrize(
+    "config",
+    [
+        ({"foo": None}),
+        ({"foo": "bar"}),
+        ({"foo": "bar"}),
+        ({"foo": "\U0001f4a9"}),
+        ({"foo": "💩"}),
+        ({"\U0001f4a9": "foo"}),
+        ({"💩": "foo"}),
+        ({"💩": "💩"}),
+    ],
+)
 def test_migrate_config_no_mock_existing_file(tmpdir, basic_spec, config):
-    new_path = tmpdir.join('config.json')
+    new_path = tmpdir.join("config.json")
     new_path.ensure()
 
-    with new_path.open(mode='w') as fp:
+    with new_path.open(mode="w") as fp:
         json.dump(config, fp)
 
     basic_spec.migrate_config_file(str(new_path), create=False)
 
-    with new_path.open(mode='r') as fp:
+    with new_path.open(mode="r") as fp:
         assert json.load(fp) == config
 
 
 def test_get_item(basic_spec):
-    assert basic_spec.get_item('foo') is not None
-    assert basic_spec.get_item('no name match') is None
+    assert basic_spec.get_item("foo") is not None
+    assert basic_spec.get_item("no name match") is None
 
 
 def test_update_defaults(basic_spec):
-    assert basic_spec.defaults == {'foo': None}
-    basic_spec.update_defaults({'foo': 'bar'})
-    assert basic_spec.defaults == {'foo': 'bar'}
+    assert basic_spec.defaults == {"foo": None}
+    basic_spec.update_defaults({"foo": "bar"})
+    assert basic_spec.defaults == {"foo": "bar"}
 
 
 def test_update_defaults_bad_key(basic_spec):
@@ -389,92 +398,100 @@ def test_update_defaults_bad_key(basic_spec):
 
 
 def test_load_config_real_world(real_world_spec):
-    parser = ArgumentParser(conflict_handler='resolve')
+    parser = ArgumentParser(conflict_handler="resolve")
     real_world_spec.add_arguments(parser, bootstrap=True)
-    cli_args = ['--file', '/path/to/file.yaml',
-                '--web-port', '1234',
-                '--ssl-public-key', '/path/to/public.crt',
-                '--ssl-private-key', '/path/to/private.key',
-                '--database-verbose'
-                ]
+    cli_args = [
+        "--file",
+        "/path/to/file.yaml",
+        "--web-port",
+        "1234",
+        "--ssl-public-key",
+        "/path/to/public.crt",
+        "--ssl-private-key",
+        "/path/to/private.key",
+        "--database-verbose",
+    ]
     cli_values = vars(parser.parse_args(cli_args))
     bootstrap_config = real_world_spec.load_config(
-        ('boostrap_cli', cli_values), 'ENVIRONMENT',
-        bootstrap=True
+        ("boostrap_cli", cli_values), "ENVIRONMENT", bootstrap=True
     )
-    os.environ['MY_APP_DATABASE_HOST'] = 'db_host_from_env'
+    os.environ["MY_APP_DATABASE_HOST"] = "db_host_from_env"
 
     # Pretend we load this from bootstrap_config.file
     # Normally, you could just specify bootstrap_config.file
     # but because we are in a test, I'm not doing that.
     config_file_dict = {
-        'ssl': {
-            'public_key': '/path/to/public/from/file.crt',
-            'private_key': '/path/to/private/from/file.key'
+        "ssl": {
+            "public_key": "/path/to/public/from/file.crt",
+            "private_key": "/path/to/private/from/file.key",
         },
-        'database': {
-            'name': 'name_from_config_file',
+        "database": {
+            "name": "name_from_config_file",
         },
-        'web_port': 8080,
+        "web_port": 8080,
     }
 
     real_world_spec.add_arguments(parser, bootstrap=False)
     cli_values = vars(parser.parse_args(cli_args))
 
-    config = real_world_spec.load_config(*[
-        ('command line', cli_values),
-        (bootstrap_config['file'], config_file_dict),
-        'ENVIRONMENT'])
+    config = real_world_spec.load_config(
+        *[
+            ("command line", cli_values),
+            (bootstrap_config["file"], config_file_dict),
+            "ENVIRONMENT",
+        ]
+    )
 
-    assert config['file'] == '/path/to/file.yaml'
-    assert config['web_port'] == 1234
-    assert config['ssl']['public_key'] == '/path/to/public.crt'
-    assert config['ssl']['private_key'] == '/path/to/private.key'
-    assert config['database']['name'] == 'name_from_config_file'
-    assert config['database']['host'] == 'db_host_from_env'
-    assert config['database']['port'] == 3306
-    assert config['database']['verbose']
+    assert config["file"] == "/path/to/file.yaml"
+    assert config["web_port"] == 1234
+    assert config["ssl"]["public_key"] == "/path/to/public.crt"
+    assert config["ssl"]["private_key"] == "/path/to/private.key"
+    assert config["database"]["name"] == "name_from_config_file"
+    assert config["database"]["host"] == "db_host_from_env"
+    assert config["database"]["port"] == 3306
+    assert config["database"]["verbose"]
 
 
-@patch('os.path.isfile', Mock(return_value=True))
+@patch("os.path.isfile", Mock(return_value=True))
 @pytest.mark.parametrize(
-    'filename,expected,always_update,update_defaults,output_file_type', [
+    "filename,expected,always_update,update_defaults,output_file_type",
+    [
         (
-            'default_current_config.yaml',
-            lf('default_current_config'),
+            "default_current_config.yaml",
+            lf("default_current_config"),
             False,
             True,
-            'yaml',
+            "yaml",
         ),
         (
-            'default_previous_config.yaml',
-            lf('default_current_config'),
+            "default_previous_config.yaml",
+            lf("default_current_config"),
             False,
             True,
-            'yaml',
+            "yaml",
         ),
         (
-            'previous_config.yaml',
+            "previous_config.yaml",
             {
-                'emoji': u'🐍',
-                'file': '/default/path/to/file.yaml',
-                'web_port': 3000,
-                'ssl': {
-                    'private_key': '/previous/path/to/private.key',
-                    'public_key': '/previous/path/to/public.crt'
+                "emoji": "🐍",
+                "file": "/default/path/to/file.yaml",
+                "web_port": 3000,
+                "ssl": {
+                    "private_key": "/previous/path/to/private.key",
+                    "public_key": "/previous/path/to/public.crt",
                 },
-                'database': {
-                    'name': 'myapp',
-                    'host': 'localhost',
-                    'port': 1234,
-                    'verbose': False
-                }
+                "database": {
+                    "name": "myapp",
+                    "host": "localhost",
+                    "port": 1234,
+                    "verbose": False,
+                },
             },
             False,
             True,
-            'json',
+            "json",
         ),
-    ]
+    ],
 )
 def test_real_world_migrations(
     real_world_spec,
@@ -482,11 +499,11 @@ def test_real_world_migrations(
     expected,
     always_update,
     update_defaults,
-    output_file_type
+    output_file_type,
 ):
-    real_world_path = os.path.join(current_dir, 'files', 'real_world')
+    real_world_path = os.path.join(current_dir, "files", "real_world")
     full_path = os.path.join(real_world_path, filename)
-    tmp_config = os.path.join(real_world_path, 'tmp')
+    tmp_config = os.path.join(real_world_path, "tmp")
 
     new_config = real_world_spec.migrate_config_file(
         full_path,
@@ -494,7 +511,7 @@ def test_real_world_migrations(
         update_defaults=update_defaults,
         always_update=always_update,
         output_file_type=output_file_type,
-        output_file_name=tmp_config
+        output_file_name=tmp_config,
     )
 
     assert new_config == expected
@@ -502,69 +519,74 @@ def test_real_world_migrations(
     assert real_world_spec.load_config(tmp_config) == expected
 
 
-@pytest.mark.parametrize('env_name,apply_prefix,env_prefix,key', [
-    ('BG_HOST', True, 'BG_', 'BG_BG_HOST'),
-    ('BG_HOST', False, 'BG_', 'BG_HOST'),
-    ('HOST', True, 'BG_', 'BG_HOST'),
-])
+@pytest.mark.parametrize(
+    "env_name,apply_prefix,env_prefix,key",
+    [
+        ("BG_HOST", True, "BG_", "BG_BG_HOST"),
+        ("BG_HOST", False, "BG_", "BG_HOST"),
+        ("HOST", True, "BG_", "BG_HOST"),
+    ],
+)
 def test_env_names_with_prefixes(env_name, apply_prefix, env_prefix, key):
     spec = YapconfSpec(
         {
-            'bg_host': {
-                'type': 'str',
-                'env_name': env_name,
-                'apply_env_prefix': apply_prefix,
+            "bg_host": {
+                "type": "str",
+                "env_name": env_name,
+                "apply_env_prefix": apply_prefix,
             }
-        }, env_prefix=env_prefix)
+        },
+        env_prefix=env_prefix,
+    )
 
-    config = spec.load_config(('ENVIRONMENT', {key: 'host_value'}))
-    assert config.bg_host == 'host_value'
+    config = spec.load_config(("ENVIRONMENT", {key: "host_value"}))
+    assert config.bg_host == "host_value"
 
 
-@pytest.mark.usefixtures('simple_spec')
-@pytest.mark.parametrize('key', [
-    '/',
-    '/foo/bar/',
-])
+@pytest.mark.usefixtures("simple_spec")
+@pytest.mark.parametrize(
+    "key",
+    [
+        "/",
+        "/foo/bar/",
+    ],
+)
 def test_load_etcd(simple_spec, key):
     children = [
-        Mock(key='%smy_string' % key, value='str_val'),
-        Mock(key='%smy_int' % key, value='123'),
-        Mock(key='%smy_long' % key, value='12341234'),
-        Mock(key='%smy_float' % key, value='123.123'),
-        Mock(key='%smy_bool' % key, value='true'),
-        Mock(key='%smy_complex' % key, value='1j'),
+        Mock(key="%smy_string" % key, value="str_val"),
+        Mock(key="%smy_int" % key, value="123"),
+        Mock(key="%smy_long" % key, value="12341234"),
+        Mock(key="%smy_float" % key, value="123.123"),
+        Mock(key="%smy_bool" % key, value="true"),
+        Mock(key="%smy_complex" % key, value="1j"),
     ]
 
     etcd_result = Mock(dir=True)
     etcd_result.children = children
     client = Mock(spec=yapconf.etcd_client.Client)
     client.read = Mock(return_value=etcd_result)
-    simple_spec.add_source('etcd', 'etcd', client=client)
-    config = simple_spec.load_config('etcd')
+    simple_spec.add_source("etcd", "etcd", client=client)
+    config = simple_spec.load_config("etcd")
     assert config == {
-        'my_string': 'str_val',
-        'my_int': 123,
-        'my_long': 12341234,
-        'my_float': 123.123,
-        'my_bool': True,
-        'my_complex': 1j,
+        "my_string": "str_val",
+        "my_int": 123,
+        "my_long": 12341234,
+        "my_float": 123.123,
+        "my_bool": True,
+        "my_complex": 1j,
     }
 
 
-@pytest.mark.parametrize('data,filename,file_type', [
-    (None, 'unicode.json', 'json'),
-    (None, 'unicode.yaml', 'yaml'),
-    (lf('example_data'), None, 'json'),
-])
-def test_load_from_source(
-    example_spec,
-    example_data,
-    data,
-    filename,
-    file_type
-):
-    example_path = os.path.join(current_dir, 'files')
+@pytest.mark.parametrize(
+    "data,filename,file_type",
+    [
+        (None, "unicode.json", "json"),
+        (None, "unicode.yaml", "yaml"),
+        (lf("example_data"), None, "json"),
+    ],
+)
+def test_load_from_source(example_spec, example_data, data, filename, file_type):
+    example_path = os.path.join(current_dir, "files")
     if filename is not None:
         full_path = os.path.join(example_path, filename)
     else:
@@ -574,37 +596,35 @@ def test_load_from_source(
         data = json.dumps(data)
 
     example_spec._file_type = file_type
-    example_spec.add_source(
-        'example',
-        file_type,
-        filename=full_path,
-        data=data
-    )
+    example_spec.add_source("example", file_type, filename=full_path, data=data)
 
-    config = example_spec.load_config('example')
+    config = example_spec.load_config("example")
     assert config == example_data
 
 
 def test_load_environment(basic_spec):
-    os.environ['FOO'] = 'foo_value'
-    config = basic_spec.load_config('ENVIRONMENT')
-    assert config.foo == 'foo_value'
+    os.environ["FOO"] = "foo_value"
+    config = basic_spec.load_config("ENVIRONMENT")
+    assert config.foo == "foo_value"
 
 
-@pytest.mark.usefixtures('simple_spec')
-@pytest.mark.parametrize('key,config_type,formatter', [
-    (None, None, None),
-    ('file.yaml', 'yaml', legacy_yaml.dump),
-    ('file.json', 'json', json.dumps),
-])
+@pytest.mark.usefixtures("simple_spec")
+@pytest.mark.parametrize(
+    "key,config_type,formatter",
+    [
+        (None, None, None),
+        ("file.yaml", "yaml", legacy_yaml.dump),
+        ("file.json", "json", json.dumps),
+    ],
+)
 def test_load_kubernetes(simple_spec, key, config_type, formatter):
     data = {
-        'my_string': 'str_val',
-        'my_int': '123',
-        'my_long': '12341234',
-        'my_float': '123.123',
-        'my_bool': 'True',
-        'my_complex': '1j',
+        "my_string": "str_val",
+        "my_int": "123",
+        "my_long": "12341234",
+        "my_float": "123.123",
+        "my_bool": "True",
+        "my_complex": "1j",
     }
     if formatter:
         data = formatter(data)
@@ -616,191 +636,188 @@ def test_load_kubernetes(simple_spec, key, config_type, formatter):
 
     client = Mock(spec=yapconf.kubernetes_client.CoreV1Api)
     client.read_namespaced_config_map = Mock(return_value=Mock(data=to_return))
-    simple_spec.add_source('kubernetes',
-                           'kubernetes',
-                           client=client,
-                           config_type=config_type,
-                           key=key)
-    config = simple_spec.load_config('kubernetes')
+    simple_spec.add_source(
+        "kubernetes", "kubernetes", client=client, config_type=config_type, key=key
+    )
+    config = simple_spec.load_config("kubernetes")
     assert config == {
-        'my_string': 'str_val',
-        'my_int': 123,
-        'my_long': 12341234,
-        'my_float': 123.123,
-        'my_bool': True,
-        'my_complex': 1j,
+        "my_string": "str_val",
+        "my_int": 123,
+        "my_long": 12341234,
+        "my_float": 123.123,
+        "my_bool": True,
+        "my_complex": 1j,
     }
 
 
 def test_defaults(fallback_spec):
     assert fallback_spec.defaults == {
-        'defaults': {
-            'str': 'default_str',
-            'int': 123,
-            'long': 123,
-            'float': 123.123,
-            'bool': True,
-            'complex': 1j,
-            'list': [1, 2, 3],
-            'dict': {'foo': 'item_default'},
+        "defaults": {
+            "str": "default_str",
+            "int": 123,
+            "long": 123,
+            "float": 123.123,
+            "bool": True,
+            "complex": 1j,
+            "list": [1, 2, 3],
+            "dict": {"foo": "item_default"},
         },
-        'str': None,
-        'int': None,
-        'long': None,
-        'float': None,
-        'bool': None,
-        'complex': None,
-        'list': None,
-        'dict': {'foo': None},
+        "str": None,
+        "int": None,
+        "long": None,
+        "float": None,
+        "bool": None,
+        "complex": None,
+        "list": None,
+        "dict": {"foo": None},
     }
 
 
-@pytest.mark.parametrize('configs,expected', [
-    (
-        [],
-        {
-            'defaults': {
-                'str': 'default_str',
-                'int': 123,
-                'long': long(123),
-                'float': 123.123,
-                'bool': True,
-                'complex': 1j,
-                'list': [1, 2, 3],
-                'dict': {'foo': 'item_default'},
-            },
-            'str': 'default_str',
-            'int': 123,
-            'long': long(123),
-            'float': 123.123,
-            'bool': True,
-            'complex': 1j,
-            'list': [1, 2, 3],
-            'dict': {'foo': 'item_default'},
-        }
-    ),
-    (
-        [
+@pytest.mark.parametrize(
+    "configs,expected",
+    [
+        (
+            [],
             {
-                'defaults': {
-                    'str': 'fallback_str',
-                    'int': 456,
-                    'long': 456,
-                    'float': 456.456,
-                    'bool': True,
-                    'complex': 4j,
-                    'list': [4, 5, 6],
-                    'dict': {'foo': 'fallback_item'}
-                }
+                "defaults": {
+                    "str": "default_str",
+                    "int": 123,
+                    "long": long(123),
+                    "float": 123.123,
+                    "bool": True,
+                    "complex": 1j,
+                    "list": [1, 2, 3],
+                    "dict": {"foo": "item_default"},
+                },
+                "str": "default_str",
+                "int": 123,
+                "long": long(123),
+                "float": 123.123,
+                "bool": True,
+                "complex": 1j,
+                "list": [1, 2, 3],
+                "dict": {"foo": "item_default"},
             },
+        ),
+        (
+            [
+                {
+                    "defaults": {
+                        "str": "fallback_str",
+                        "int": 456,
+                        "long": 456,
+                        "float": 456.456,
+                        "bool": True,
+                        "complex": 4j,
+                        "list": [4, 5, 6],
+                        "dict": {"foo": "fallback_item"},
+                    }
+                },
+                {
+                    "str": "override_str",
+                    "int": 789,
+                    "long": 789,
+                    "float": 789.789,
+                    "bool": False,
+                    "complex": 7j,
+                    "list": [7, 8, 9],
+                    "dict": {"foo": "override_item"},
+                },
+            ],
             {
-                'str': 'override_str',
-                'int': 789,
-                'long': 789,
-                'float': 789.789,
-                'bool': False,
-                'complex': 7j,
-                'list': [7, 8, 9],
-                'dict': {'foo': 'override_item'}
-            }
-        ],
-        {
-            'defaults': {
-                'str': 'fallback_str',
-                'int': 456,
-                'long': long(456),
-                'float': 456.456,
-                'bool': True,
-                'complex': 4j,
-                'list': [4, 5, 6],
-                'dict': {'foo': 'fallback_item'},
+                "defaults": {
+                    "str": "fallback_str",
+                    "int": 456,
+                    "long": long(456),
+                    "float": 456.456,
+                    "bool": True,
+                    "complex": 4j,
+                    "list": [4, 5, 6],
+                    "dict": {"foo": "fallback_item"},
+                },
+                "str": "override_str",
+                "int": 789,
+                "long": long(789),
+                "float": 789.789,
+                "bool": False,
+                "complex": 7j,
+                "list": [7, 8, 9],
+                "dict": {"foo": "override_item"},
             },
-            'str': 'override_str',
-            'int': 789,
-            'long': long(789),
-            'float': 789.789,
-            'bool': False,
-            'complex': 7j,
-            'list': [7, 8, 9],
-            'dict': {'foo': 'override_item'},
-        }
-    ),
-    (
-        [
+        ),
+        (
+            [
+                {
+                    "defaults": {
+                        "str": "fallback_str",
+                        "int": 456,
+                        "long": 456,
+                        "float": 456.456,
+                        "bool": True,
+                        "complex": 4j,
+                        "list": [4, 5, 6],
+                        "dict": {"foo": "fallback_item"},
+                    }
+                },
+                {
+                    "int": 789,
+                    "long": 789,
+                    "bool": False,
+                    "list": [7, 8, 9],
+                },
+            ],
             {
-                'defaults': {
-                    'str': 'fallback_str',
-                    'int': 456,
-                    'long': 456,
-                    'float': 456.456,
-                    'bool': True,
-                    'complex': 4j,
-                    'list': [4, 5, 6],
-                    'dict': {'foo': 'fallback_item'}
-                }
+                "defaults": {
+                    "str": "fallback_str",
+                    "int": 456,
+                    "long": long(456),
+                    "float": 456.456,
+                    "bool": True,
+                    "complex": 4j,
+                    "list": [4, 5, 6],
+                    "dict": {"foo": "fallback_item"},
+                },
+                "str": "fallback_str",
+                "int": 789,
+                "long": long(789),
+                "float": 456.456,
+                "bool": False,
+                "complex": 4j,
+                "list": [7, 8, 9],
+                "dict": {"foo": "fallback_item"},
             },
-            {
-                'int': 789,
-                'long': 789,
-                'bool': False,
-                'list': [7, 8, 9],
-            }
-        ],
-        {
-            'defaults': {
-                'str': 'fallback_str',
-                'int': 456,
-                'long': long(456),
-                'float': 456.456,
-                'bool': True,
-                'complex': 4j,
-                'list': [4, 5, 6],
-                'dict': {'foo': 'fallback_item'},
-            },
-            'str': 'fallback_str',
-            'int': 789,
-            'long': long(789),
-            'float': 456.456,
-            'bool': False,
-            'complex': 4j,
-            'list': [7, 8, 9],
-            'dict': {'foo': 'fallback_item'},
-        }
-    ),
-])
+        ),
+    ],
+)
 def test_fallbacks(fallback_spec, configs, expected):
     config = fallback_spec.load_config(*configs)
     assert config == expected
 
 
 def test_generate_documentation_file(real_world_spec, tmpdir):
-    new_path = tmpdir.join('real_world_doc.md')
+    new_path = tmpdir.join("real_world_doc.md")
     new_path.ensure()
-    tmp_path = os.path.join(current_dir, 'files', 'real_world', 'doc.md')
+    tmp_path = os.path.join(current_dir, "files", "real_world", "doc.md")
 
     real_world_spec.add_source(
-        'Source 1 Label', 'etcd', client=Mock(spec=yapconf.etcd_client.Client)
+        "Source 1 Label", "etcd", client=Mock(spec=yapconf.etcd_client.Client)
     )
-    real_world_spec.add_source('Source 2 Label', 'dict', data={})
-    real_world_spec.add_source('Source 3 Label', 'environment')
-    real_world_spec.add_source('Source 4 Label', 'json', data={})
+    real_world_spec.add_source("Source 2 Label", "dict", data={})
+    real_world_spec.add_source("Source 3 Label", "environment")
+    real_world_spec.add_source("Source 4 Label", "json", data={})
+    real_world_spec.add_source("Source 5 Label", "json", filename="/path/to/file.json")
     real_world_spec.add_source(
-        'Source 5 Label', 'json', filename='/path/to/file.json'
-    )
-    real_world_spec.add_source(
-        'Source 6 Label',
-        'kubernetes',
+        "Source 6 Label",
+        "kubernetes",
         client=Mock(spec=yapconf.kubernetes_client.CoreV1Api),
-        key='key_name',
-        name='config_map_name',
-        namespace='config_map_namespace',
-        config_type='json'
+        key="key_name",
+        name="config_map_name",
+        namespace="config_map_namespace",
+        config_type="json",
     )
-    real_world_spec.add_source(
-        'Source 7 Label', 'yaml', filename='/path/to/file.yaml'
-    )
+    real_world_spec.add_source("Source 7 Label", "yaml", filename="/path/to/file.yaml")
     real_world_spec.generate_documentation(
-        'My App Name', output_file_name=str(new_path)
+        "My App Name", output_file_name=str(new_path)
     )
 
     with new_path.open() as fp:
@@ -812,92 +829,94 @@ def test_generate_documentation_file(real_world_spec, tmpdir):
     assert generated_docs == expected
 
 
-@pytest.mark.parametrize('spec,fq_name', [
-    (lf('real_world_spec'), 'file'),
-    (lf('real_world_spec'), 'emoji'),
-    (lf('real_world_spec'), 'ssl.private_key'),
-    (lf('spec_with_lists'), 'simple_list'),
-])
+@pytest.mark.parametrize(
+    "spec,fq_name",
+    [
+        (lf("real_world_spec"), "file"),
+        (lf("real_world_spec"), "emoji"),
+        (lf("real_world_spec"), "ssl.private_key"),
+        (lf("spec_with_lists"), "simple_list"),
+    ],
+)
 def test_find_item(spec, fq_name):
     item = spec.find_item(fq_name)
     assert item.fq_name == fq_name
 
 
 def test_spawn_watcher(simple_spec):
-    simple_spec.add_source('label', 'dict', data={})
+    simple_spec.add_source("label", "dict", data={})
     mock_watch = Mock()
-    simple_spec._sources['label'].watch = mock_watch
-    simple_spec.spawn_watcher('label')
+    simple_spec._sources["label"].watch = mock_watch
+    simple_spec.spawn_watcher("label")
     assert mock_watch.call_count == 1
 
 
 def test_spawn_watcher_error(simple_spec):
     with pytest.raises(YapconfSourceError):
-        simple_spec.spawn_watcher('LABEL_NOT_DEFINED')
+        simple_spec.spawn_watcher("LABEL_NOT_DEFINED")
 
 
-@pytest.mark.parametrize('label', [
-    'label1',
-    'label2',
-    'label3',
-])
+@pytest.mark.parametrize(
+    "label",
+    [
+        "label1",
+        "label2",
+        "label3",
+    ],
+)
 def test_watchers(real_world_spec, label):
     original_data = {
-        'database': {
-            'host': '1.2.3.4',
-            'name': 'myapp_prod',
-            'port': 3307,
-            'verbose': False,
+        "database": {
+            "host": "1.2.3.4",
+            "name": "myapp_prod",
+            "port": 3307,
+            "verbose": False,
         },
-        'emoji': u'💩',
-        'file': '/path/to/file.yaml',
-        'ssl': {
-            'private_key': 'blah',
-            'public_key': 'blah',
+        "emoji": "💩",
+        "file": "/path/to/file.yaml",
+        "ssl": {
+            "private_key": "blah",
+            "public_key": "blah",
         },
-        'web_port': 443,
+        "web_port": 443,
     }
     safe_data = copy.deepcopy(original_data)
-    flags = {'overall': True, 'individual': True}
-    real_world_path = os.path.join(current_dir, 'files', 'real_world')
+    flags = {"overall": True, "individual": True}
+    real_world_path = os.path.join(current_dir, "files", "real_world")
 
     def overall_handler(old_config, new_config):
-        flags['overall'] = False
+        flags["overall"] = False
 
     def indivual_handler(old_value, new_value):
-        flags['individual'] = False
+        flags["individual"] = False
 
     def change_config(label):
-        if label == 'label1':
-            config = real_world_spec.load_config('label1')
+        if label == "label1":
+            config = real_world_spec.load_config("label1")
             config.database.port += 1
             yapconf.dump_data(
-                config.to_dict(),
-                filename=yaml_filename,
-                file_type='yaml'
+                config.to_dict(), filename=yaml_filename, file_type="yaml"
             )
 
-        elif label == 'label2':
-            config = real_world_spec.load_config('label2')
+        elif label == "label2":
+            config = real_world_spec.load_config("label2")
             config.database.port += 1
             yapconf.dump_data(
-                config.to_dict(),
-                filename=json_filename,
-                file_type='json'
+                config.to_dict(), filename=json_filename, file_type="json"
             )
 
-        elif label == 'label3':
-            safe_data['database']['port'] += 1
+        elif label == "label3":
+            safe_data["database"]["port"] += 1
 
-    item = real_world_spec.find_item('database.port')
+    item = real_world_spec.find_item("database.port")
     item.watch_target = indivual_handler
 
-    yaml_filename = os.path.join(real_world_path, 'config_to_change.yaml')
-    json_filename = os.path.join(real_world_path, 'config_to_change.json')
+    yaml_filename = os.path.join(real_world_path, "config_to_change.yaml")
+    json_filename = os.path.join(real_world_path, "config_to_change.json")
 
-    real_world_spec.add_source('label1', 'yaml', filename=yaml_filename)
-    real_world_spec.add_source('label2', 'json', filename=json_filename)
-    real_world_spec.add_source('label3', 'dict', data=safe_data)
+    real_world_spec.add_source("label1", "yaml", filename=yaml_filename)
+    real_world_spec.add_source("label2", "json", filename=json_filename)
+    real_world_spec.add_source("label3", "dict", data=safe_data)
 
     real_world_spec.spawn_watcher(label, target=overall_handler)
     time.sleep(0.1)

--- a/tests/yapconf_test.py
+++ b/tests/yapconf_test.py
@@ -11,227 +11,207 @@ import yapconf
 
 @pytest.fixture
 def ascii_data():
-    return {
-        'foo': 'bar',
-        'db': {'name': 'db_name', 'port': 123},
-        'items': [1, 2, 3]
-    }
+    return {"foo": "bar", "db": {"name": "db_name", "port": 123}, "items": [1, 2, 3]}
 
 
 @pytest.fixture
 def unicode_data():
     return {
-        u'foo': u'bar',
-        'db': {'name': 'db_name', 'port': 123},
-        'items': [1, 2, 3],
-        u'💩': u'🐍',
-        'emoji': u'💩'
+        "foo": "bar",
+        "db": {"name": "db_name", "port": 123},
+        "items": [1, 2, 3],
+        "💩": "🐍",
+        "emoji": "💩",
     }
 
 
-@pytest.mark.parametrize('orig,expected', [
-    ('CamelCase', 'camel_case'),
-    ('CamelCamelCase', 'camel_camel_case'),
-    ('Camel2Camel2Case', 'camel2_camel2_case'),
-    ('getHTTPResponseCode', 'get_http_response_code'),
-    ('get2HTTPResponseCode', 'get2_http_response_code'),
-    ('HTTPResponseCode', 'http_response_code'),
-    ('HTTPResponseCodeXYZ', 'http_response_code_xyz'),
-    ('snake-case', 'snake_case'),
-    ('snake-snake-case', 'snake_snake_case'),
-    ('snake2-snake2-case', 'snake2_snake2_case'),
-    ('snake3-snake3_case', 'snake3_snake3_case'),
-    (
-        ' CamelGetHTTPResponse_code_snake2_case is a pain',
-        'camel_get_http_response_code_snake2_case_is_a_pain'
-    ),
-])
+@pytest.mark.parametrize(
+    "orig,expected",
+    [
+        ("CamelCase", "camel_case"),
+        ("CamelCamelCase", "camel_camel_case"),
+        ("Camel2Camel2Case", "camel2_camel2_case"),
+        ("getHTTPResponseCode", "get_http_response_code"),
+        ("get2HTTPResponseCode", "get2_http_response_code"),
+        ("HTTPResponseCode", "http_response_code"),
+        ("HTTPResponseCodeXYZ", "http_response_code_xyz"),
+        ("snake-case", "snake_case"),
+        ("snake-snake-case", "snake_snake_case"),
+        ("snake2-snake2-case", "snake2_snake2_case"),
+        ("snake3-snake3_case", "snake3_snake3_case"),
+        (
+            " CamelGetHTTPResponse_code_snake2_case is a pain",
+            "camel_get_http_response_code_snake2_case_is_a_pain",
+        ),
+    ],
+)
 def test_convert_to_snake(orig, expected):
-    assert expected == yapconf.change_case(orig, separator='_')
+    assert expected == yapconf.change_case(orig, separator="_")
 
 
-@pytest.mark.parametrize('orig,expected', [
-    ('CamelCase', 'camel-case'),
-    ('CamelCamelCase', 'camel-camel-case'),
-    ('Camel2Camel2Case', 'camel2-camel2-case'),
-    ('getHTTPResponseCode', 'get-http-response-code'),
-    ('get2HTTPResponseCode', 'get2-http-response-code'),
-    ('HTTPResponseCode', 'http-response-code'),
-    ('HTTPResponseCodeXYZ', 'http-response-code-xyz'),
-    ('snake_case', 'snake-case'),
-    ('snake_snake_case', 'snake-snake-case'),
-    ('snake2_snake2_case', 'snake2-snake2-case'),
-    ('snake3_snake3-case', 'snake3-snake3-case'),
-    (' CamelGetHTTPResponse_code_snake2_case is a pain',
-     'camel-get-http-response-code-snake2-case-is-a-pain')
-])
+@pytest.mark.parametrize(
+    "orig,expected",
+    [
+        ("CamelCase", "camel-case"),
+        ("CamelCamelCase", "camel-camel-case"),
+        ("Camel2Camel2Case", "camel2-camel2-case"),
+        ("getHTTPResponseCode", "get-http-response-code"),
+        ("get2HTTPResponseCode", "get2-http-response-code"),
+        ("HTTPResponseCode", "http-response-code"),
+        ("HTTPResponseCodeXYZ", "http-response-code-xyz"),
+        ("snake_case", "snake-case"),
+        ("snake_snake_case", "snake-snake-case"),
+        ("snake2_snake2_case", "snake2-snake2-case"),
+        ("snake3_snake3-case", "snake3-snake3-case"),
+        (
+            " CamelGetHTTPResponse_code_snake2_case is a pain",
+            "camel-get-http-response-code-snake2-case-is-a-pain",
+        ),
+    ],
+)
 def test_convert_to_kebab(orig, expected):
     assert expected == yapconf.change_case(orig)
 
 
-@pytest.mark.parametrize('filename,file_type,expected', [
-    (
-        'ascii.yaml',
-        'yaml',
-        lf('ascii_data')
-    ),
-    (
-        'unicode.yaml',
-        'yaml',
-        lf('unicode_data')
-    ),
-    (
-        'ascii.json',
-        'json',
-        lf('ascii_data')
-    ),
-    (
-        'unicode.json',
-        'json',
-        lf('unicode_data')
-    ),
-])
+@pytest.mark.parametrize(
+    "filename,file_type,expected",
+    [
+        ("ascii.yaml", "yaml", lf("ascii_data")),
+        ("unicode.yaml", "yaml", lf("unicode_data")),
+        ("ascii.json", "json", lf("ascii_data")),
+        ("unicode.json", "json", lf("unicode_data")),
+    ],
+)
 def test_load_file(filename, file_type, expected):
     current_dir = os.path.abspath(os.path.dirname(__file__))
-    full_path = os.path.join(current_dir, 'files', filename)
+    full_path = os.path.join(current_dir, "files", filename)
     data = yapconf.load_file(full_path, file_type=file_type)
     assert data == expected
 
 
-@pytest.mark.parametrize('filename,file_type', [
-    ('bad.json', 'json'),
-    ('ascii.json', 'INVALID_TYPE'),
-])
+@pytest.mark.parametrize(
+    "filename,file_type",
+    [
+        ("bad.json", "json"),
+        ("ascii.json", "INVALID_TYPE"),
+    ],
+)
 def test_load_file_error(filename, file_type):
     current_dir = os.path.abspath(os.path.dirname(__file__))
-    full_path = os.path.join(current_dir, 'files', filename)
+    full_path = os.path.join(current_dir, "files", filename)
     with pytest.raises(ValueError):
-        yapconf.load_file(full_path,
-                          file_type=file_type,
-                          klazz=ValueError)
+        yapconf.load_file(full_path, file_type=file_type, klazz=ValueError)
 
 
-@pytest.mark.parametrize('data,file_type', [
-    (
-        lf('ascii_data'),
-        'yaml'
-    ),
-    (
-        lf('unicode_data'),
-        'yaml'
-    ),
-    (
-        lf('unicode_data'),
-        'json'
-    ),
-    (
-        lf('ascii_data'),
-        'json'
-    )
-])
+@pytest.mark.parametrize(
+    "data,file_type",
+    [
+        (lf("ascii_data"), "yaml"),
+        (lf("unicode_data"), "yaml"),
+        (lf("unicode_data"), "json"),
+        (lf("ascii_data"), "json"),
+    ],
+)
 def test_dump_data(tmpdir, data, file_type):
-    path = tmpdir.join('test.%s' % file_type)
+    path = tmpdir.join("test.%s" % file_type)
     filename = os.path.join(path.dirname, path.basename)
     yapconf.dump_data(data, filename, file_type)
     assert data == yapconf.load_file(filename, file_type)
 
 
 def test_dump_box(ascii_data):
-    data = {'writes': ''}
+    data = {"writes": ""}
 
     def mock_write(x):
-        data['writes'] += x
+        data["writes"] += x
 
     expected = (
-        'db:{n}'
-        '  name: db_name{n}'
-        '  port: 123{n}'
-        'foo: bar{n}'
-        'items:{n}'
-        '- 1{n}'
-        '- 2{n}'
-        '- 3{n}'
+        "db:{n}"
+        "  name: db_name{n}"
+        "  port: 123{n}"
+        "foo: bar{n}"
+        "items:{n}"
+        "- 1{n}"
+        "- 2{n}"
+        "- 3{n}"
     ).format(n=os.linesep)
 
     boxed_data = Box(ascii_data)
-    with patch('sys.stdout.write', mock_write):
-        yapconf.dump_data(boxed_data, file_type='yaml')
+    with patch("sys.stdout.write", mock_write):
+        yapconf.dump_data(boxed_data, file_type="yaml")
 
-    assert data['writes'] == expected
+    assert data["writes"] == expected
 
 
-@pytest.mark.parametrize('original,expected', [
-    ({}, {}),
-    ({'foo': 'bar'}, {'foo': 'bar'}),
-    ({'foo': {'bar': 'baz'}}, {'foo.bar': 'baz'}),
-    (
-        {'foo': {'bar': {'baz': 'bat', 'bax': 'bat'}, 'bat': 'bar'}},
-        {'foo.bar.baz': 'bat', 'foo.bar.bax': 'bat', 'foo.bat': 'bar'}
-    ),
-    (
-        {
-            'list': [
-                {'foo': 'foo_value', 'bar': 'bar_value'},
-                {'foo': 'foo_value2', 'bar': 'bar_value2'},
-            ]
-        },
-        {
-            'list': [
-                {'list.foo': 'foo_value', 'list.bar': 'bar_value'},
-                {'list.foo': 'foo_value2', 'list.bar': 'bar_value2'}
-            ]
-        }
-    ),
-    (
-        {
-            'foo': {'list1': [1], 'list2': [{'bar': 'baz'}]}
-        },
-        {
-            'foo.list1': [1], 'foo.list2': [{'foo.list2.bar': 'baz'}]
-        }
-    ),
-    (
-        {
-            'foo': {
-                'list1': [
-                    {
-                        'bar': {
-                            'list2': [1, 2, 3],
-                            'bar2': 'bar2_value',
-                            'bat': {
-                                'bat2': 'bat2_value',
-                                'bat_list_dict': [
-                                    {
-                                        'baz': 'baz_value',
-                                        'bazl': [4, 5, 6],
-                                        'bazd': {'bazd_key': 'bazd_value'}
-                                    }
-                                ]
+@pytest.mark.parametrize(
+    "original,expected",
+    [
+        ({}, {}),
+        ({"foo": "bar"}, {"foo": "bar"}),
+        ({"foo": {"bar": "baz"}}, {"foo.bar": "baz"}),
+        (
+            {"foo": {"bar": {"baz": "bat", "bax": "bat"}, "bat": "bar"}},
+            {"foo.bar.baz": "bat", "foo.bar.bax": "bat", "foo.bat": "bar"},
+        ),
+        (
+            {
+                "list": [
+                    {"foo": "foo_value", "bar": "bar_value"},
+                    {"foo": "foo_value2", "bar": "bar_value2"},
+                ]
+            },
+            {
+                "list": [
+                    {"list.foo": "foo_value", "list.bar": "bar_value"},
+                    {"list.foo": "foo_value2", "list.bar": "bar_value2"},
+                ]
+            },
+        ),
+        (
+            {"foo": {"list1": [1], "list2": [{"bar": "baz"}]}},
+            {"foo.list1": [1], "foo.list2": [{"foo.list2.bar": "baz"}]},
+        ),
+        (
+            {
+                "foo": {
+                    "list1": [
+                        {
+                            "bar": {
+                                "list2": [1, 2, 3],
+                                "bar2": "bar2_value",
+                                "bat": {
+                                    "bat2": "bat2_value",
+                                    "bat_list_dict": [
+                                        {
+                                            "baz": "baz_value",
+                                            "bazl": [4, 5, 6],
+                                            "bazd": {"bazd_key": "bazd_value"},
+                                        }
+                                    ],
+                                },
                             }
                         }
+                    ]
+                }
+            },
+            {
+                "foo.list1": [
+                    {
+                        "foo.list1.bar.list2": [1, 2, 3],
+                        "foo.list1.bar.bar2": "bar2_value",
+                        "foo.list1.bar.bat.bat2": "bat2_value",
+                        "foo.list1.bar.bat.bat_list_dict": [
+                            {
+                                "foo.list1.bar.bat.bat_list_dict.baz": "baz_value",
+                                "foo.list1.bar.bat.bat_list_dict.bazl": [4, 5, 6],
+                                "foo.list1.bar.bat.bat_list_dict.bazd.bazd_key": "bazd_value",
+                            }
+                        ],
                     }
                 ]
-            }
-        },
-        {
-            'foo.list1': [
-                {
-                    'foo.list1.bar.list2': [1, 2, 3],
-                    'foo.list1.bar.bar2': 'bar2_value',
-                    'foo.list1.bar.bat.bat2': 'bat2_value',
-                    'foo.list1.bar.bat.bat_list_dict': [
-                        {
-                            'foo.list1.bar.bat.bat_list_dict.baz': 'baz_value',
-                            'foo.list1.bar.bat.bat_list_dict.bazl': [4, 5, 6],
-                            'foo.list1.bar.bat.bat_list_dict.bazd.bazd_key':
-                                'bazd_value'
-                        }
-                    ]
-
-                }
-            ]
-        }
-    )
-])
+            },
+        ),
+    ],
+)
 def test_flatten(original, expected):
     assert yapconf.flatten(original) == expected

--- a/tests/yapconf_test.py
+++ b/tests/yapconf_test.py
@@ -204,7 +204,9 @@ def test_dump_box(ascii_data):
                             {
                                 "foo.list1.bar.bat.bat_list_dict.baz": "baz_value",
                                 "foo.list1.bar.bat.bat_list_dict.bazl": [4, 5, 6],
-                                "foo.list1.bar.bat.bat_list_dict.bazd.bazd_key": "bazd_value",
+                                (
+                                    "foo.list1.bar.bat.bat_list_dict.bazd.bazd_key"
+                                ): "bazd_value",
                             }
                         ],
                     }

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -4,16 +4,10 @@ import json
 import re
 import sys
 
-import six
 from box import Box
 
-if six.PY3:
-    from collections.abc import MutableMapping
+from collections.abc import MutableMapping
 
-    unicode = str
-else:
-    from collections import MutableMapping
-    from io import open
 
 # Setup feature flags for use throughout the package.
 yaml_support = True
@@ -171,10 +165,8 @@ def _dump(data, stream, file_type, **kwargs):
 
     if str(file_type).lower() == "json":
         dumped = json.dumps(data, **kwargs)
-        if isinstance(dumped, unicode):
+        if isinstance(dumped, str):
             stream.write(dumped)
-        else:
-            stream.write(six.u(dumped))
     elif str(file_type).lower() == "yaml":
         # Depending on the yaml module loaded, need to handle arguments differently
         if type(yaml).__name__ == "YAML":

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -4,7 +4,6 @@ import json
 import re
 import sys
 
-import packaging.version
 import six
 from box import Box
 

--- a/yapconf/__init__.py
+++ b/yapconf/__init__.py
@@ -32,15 +32,9 @@ try:
     # will throw warnings. Since we don't want that to happen, and
     # we want our code to be the same whether or not PyYaml or
     # ruamel.yaml is installed.
-    import ruamel.yaml as yaml
+    from ruamel.yaml import YAML
 
-    # ruamel.yaml depricated support for safe_load in 0.17.0
-    if packaging.version.parse(yaml.__version__) < packaging.version.parse("0.18.0"):
-        yaml.load = yaml.safe_load
-    else:
-        from ruamel.yaml import YAML
-
-        yaml = YAML(typ="safe", pure=True)
+    yaml = YAML(typ="safe", pure=True)
 
 
 except ImportError:
@@ -183,7 +177,12 @@ def _dump(data, stream, file_type, **kwargs):
         else:
             stream.write(six.u(dumped))
     elif str(file_type).lower() == "yaml":
-        yaml.safe_dump(data, stream, **kwargs)
+        # Depending on the yaml module loaded, need to handle arguments differently
+        if type(yaml).__name__ == "YAML":
+            yaml.default_flow_style = kwargs.get("default_flow_style", False)
+            yaml.dump(data, stream)
+        else:
+            yaml.dump(data, stream, **kwargs)
     else:
         raise NotImplementedError(
             "Someone forgot to implement dump for file " "type: %s" % file_type
@@ -225,7 +224,11 @@ def load_file(
         if str(file_type).lower() == "json":
             data = json.load(conf_file, **load_kwargs)
         elif str(file_type).lower() == "yaml":
-            data = yaml.load(conf_file.read())
+            # Depending on the yaml module loaded, need to handle arguments differently
+            if type(yaml).__name__ == "YAML":
+                data = yaml.load(conf_file.read())
+            else:
+                data = yaml.safe_load(conf_file.read())
         else:
             raise NotImplementedError(
                 "Someone forgot to implement how to load a %s file_type." % file_type

--- a/yapconf/docs.py
+++ b/yapconf/docs.py
@@ -189,7 +189,10 @@ def _generate_source_description(source, app_name, source_label):
 
 
 def _generate_source_section(source_label, source, app_name):
-    source_type_link = "[%s](%s)" % (source.type, SOURCE_TYPE_LINKS[source.type],)
+    source_type_link = "[%s](%s)" % (
+        source.type,
+        SOURCE_TYPE_LINKS[source.type],
+    )
 
     source_type_description = _generate_source_description(
         source, app_name, source_label
@@ -212,13 +215,31 @@ def _generate_item_table(item):
         cli_names = None
 
     rows = [
-        {"attribute": "**item_type**", "value": "`%s`" % item.item_type,},
-        {"attribute": "**default**", "value": "`%s`" % item.default,},
-        {"attribute": "**env_name**", "value": "`%s`" % item.env_name,},
-        {"attribute": "**required**", "value": "`%s`" % item.required,},
-        {"attribute": "**cli_name**", "value": "`%s`" % cli_names,},
+        {
+            "attribute": "**item_type**",
+            "value": "`%s`" % item.item_type,
+        },
+        {
+            "attribute": "**default**",
+            "value": "`%s`" % item.default,
+        },
+        {
+            "attribute": "**env_name**",
+            "value": "`%s`" % item.env_name,
+        },
+        {
+            "attribute": "**required**",
+            "value": "`%s`" % item.required,
+        },
+        {
+            "attribute": "**cli_name**",
+            "value": "`%s`" % cli_names,
+        },
         {"attribute": "**fallback**", "value": "`%s`" % item.fallback},
-        {"attribute": "**choices**", "value": "`%s`" % item.choices,},
+        {
+            "attribute": "**choices**",
+            "value": "`%s`" % item.choices,
+        },
     ]
     return build_markdown_table(headers, rows, ["attribute", "value"])
 
@@ -238,7 +259,9 @@ def _generate_item_options(item, app_name):
         options.append(
             "You can set `{name}` from the command-line by specifying "
             "`{cli_names}` at {app_name}'s entrypoint.".format(
-                name=item.fq_name, cli_names=cli_names, app_name=app_name,
+                name=item.fq_name,
+                cli_names=cli_names,
+                app_name=app_name,
             )
         )
 
@@ -350,7 +373,9 @@ def generate_markdown_doc(app_name, spec):
 
     sections.append(
         build_markdown_table(
-            headers, table_rows, ["name", "type", "default", "description"],
+            headers,
+            table_rows,
+            ["name", "type", "default", "description"],
         )
     )
     for item_section in item_sections:

--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -5,8 +5,6 @@ import copy
 import logging
 import sys
 
-import six
-
 import yapconf
 from yapconf.actions import AppendBoolean, AppendReplace, MergeAction
 from yapconf.exceptions import (YapconfDictItemError, YapconfItemError,
@@ -46,7 +44,7 @@ def from_specification(
 
     """
     items = {}
-    for item_name, item_info in six.iteritems(specification):
+    for item_name, item_info in specification.items():
         names = copy.copy(parent_names) if parent_names else []
         items[item_name] = _generate_item(
             item_name, item_info, env_prefix, separator, names
@@ -698,7 +696,7 @@ class YapconfBoolItem(YapconfItem):
         Returns:
 
         """
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = value.lower()
 
         if value in self.TRUTHY_VALUES:
@@ -921,7 +919,7 @@ class YapconfDictItem(YapconfItem):
     def get_config_value(self, overrides, skip_environment=False):
         converted_value = {
             child_name: child_item.get_config_value(overrides, skip_environment)
-            for child_name, child_item in six.iteritems(self.children)
+            for child_name, child_item in self.children.items()
         }
         self._validate_value(converted_value)
         return converted_value
@@ -940,7 +938,7 @@ class YapconfDictItem(YapconfItem):
             return None
 
         filtered_items = {}
-        for child_name, child_item in six.iteritems(self.children):
+        for child_name, child_item in self.children.items():
             result = child_item.apply_filter(**kwargs)
             if result is not None:
                 filtered_items[child_name] = result
@@ -969,7 +967,7 @@ class YapconfDictItem(YapconfItem):
     def convert_config_value(self, value, label):
         return {
             child_name: child_item.get_config_value([(label, value)])
-            for child_name, child_item in six.iteritems(self.children)
+            for child_name, child_item in self.children.items()
         }
 
     def _has_cli_support(self, child_of_list=False):

--- a/yapconf/items.py
+++ b/yapconf/items.py
@@ -9,13 +9,9 @@ import six
 
 import yapconf
 from yapconf.actions import AppendBoolean, AppendReplace, MergeAction
-from yapconf.exceptions import (
-    YapconfDictItemError,
-    YapconfItemError,
-    YapconfItemNotFound,
-    YapconfListItemError,
-    YapconfValueError,
-)
+from yapconf.exceptions import (YapconfDictItemError, YapconfItemError,
+                                YapconfItemNotFound, YapconfListItemError,
+                                YapconfValueError)
 
 if sys.version_info > (3,):
     long = int
@@ -365,7 +361,8 @@ class YapconfItem(object):
 
         if override is None and self.default is None and self.required:
             raise YapconfItemNotFound(
-                "Could not find config value for {0}".format(self.fq_name), self,
+                "Could not find config value for {0}".format(self.fq_name),
+                self,
             )
 
         if override is None:
@@ -459,7 +456,8 @@ class YapconfItem(object):
 
         if self.format_env:
             return yapconf.change_case(
-                self.env_prefix + "_".join(self.fq_name.split(self.separator)), "_",
+                self.env_prefix + "_".join(self.fq_name.split(self.separator)),
+                "_",
             ).upper()
         else:
             return "".join(self.fq_name.split(self.separator))

--- a/yapconf/sources.py
+++ b/yapconf/sources.py
@@ -489,9 +489,14 @@ class KubernetesConfigSource(ConfigSource):
 
         nested_config = result.data[self.key]
         if self.config_type == "json":
-            return json.loads(nested_config,)
+            return json.loads(
+                nested_config,
+            )
         elif self.config_type == "yaml":
-            return yapconf.yaml.load(nested_config)
+            if type(yapconf.yaml).__name__ == "YAML":
+                return yapconf.yaml.load(nested_config)
+            else:
+                return yapconf.yaml.safe_load(nested_config)
         else:
             raise NotImplementedError(
                 "Cannot load config with type %s" % self.config_type

--- a/yapconf/sources.py
+++ b/yapconf/sources.py
@@ -8,7 +8,6 @@ import time
 import warnings
 from argparse import ArgumentParser
 
-import six
 from watchdog.observers import Observer
 
 import yapconf
@@ -100,8 +99,7 @@ def get_source(label, source_type, **kwargs):
         raise NotImplementedError("No implementation for source type %s" % source_type)
 
 
-@six.add_metaclass(abc.ABCMeta)
-class ConfigSource(object):
+class ConfigSource(metaclass=abc.ABCMeta):
     """Base class for a configuration source.
 
     Config sources will be used to generate overrides during configuration

--- a/yapconf/sources.py
+++ b/yapconf/sources.py
@@ -248,8 +248,10 @@ class JsonConfigSource(ConfigSource):
         self._load_kwargs = kwargs
 
         if "encoding" in self._load_kwargs and not yapconf.json_encode_support:
-            warnings.warn("encoding passed to json source config but 3.9 "
-                          "dropped support for encoding. This will be ignored.")
+            warnings.warn(
+                "encoding passed to json source config but 3.9 "
+                "dropped support for encoding. This will be ignored."
+            )
             del self._load_kwargs["encoding"]
 
         if "encoding" not in self._load_kwargs and yapconf.json_encode_support:
@@ -386,7 +388,11 @@ class EtcdConfigSource(ConfigSource):
             raise YapconfSourceError(
                 "Invalid source (%s). Client must be supplied and must be of "
                 "type %s. Got type: %s"
-                % (self.label, type(yapconf.etcd_client.Client), type(self.client),)
+                % (
+                    self.label,
+                    type(yapconf.etcd_client.Client),
+                    type(self.client),
+                )
             )
 
     def get_data(self):

--- a/yapconf/spec.py
+++ b/yapconf/spec.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 
-import six
 from box import Box
 
 import yapconf
@@ -73,7 +72,7 @@ class YapconfSpec(object):
         self._sources = {}
 
     def _load_specification(self, specification):
-        if isinstance(specification, six.string_types):
+        if isinstance(specification, str):
             specification = yapconf.load_file(
                 specification,
                 file_type=self._file_type,
@@ -91,7 +90,7 @@ class YapconfSpec(object):
         return specification
 
     def _validate_specification(self, specification):
-        for item_name, item_info in six.iteritems(specification):
+        for item_name, item_info in specification.items():
             if not isinstance(item_info, dict):
                 raise YapconfSpecError(
                     "Invalid specification. {0} is not a "
@@ -244,7 +243,7 @@ class YapconfSpec(object):
                 constitute an update to the default.
 
         """
-        for key, value in six.iteritems(new_defaults):
+        for key, value in new_defaults.items():
             item = self.get_item(key)
             if item is None:
                 raise YapconfItemNotFound(
@@ -305,7 +304,7 @@ class YapconfSpec(object):
         """
         overrides = self._generate_overrides(*args)
         filtered_items = {}
-        for item_name, item in six.iteritems(self._yapconf_items):
+        for item_name, item in self._yapconf_items.items():
             result = item.apply_filter(**kwargs)
             if result is not None:
                 filtered_items[item_name] = result
@@ -584,7 +583,7 @@ class YapconfSpec(object):
     def _extract_source(self, index, override):
         label, unpacked_value, file_type = self._explode_override(override)
 
-        if isinstance(unpacked_value, six.string_types):
+        if isinstance(unpacked_value, str):
             return self._extract_string_source(label, unpacked_value, file_type)
 
         elif isinstance(unpacked_value, dict):

--- a/yapconf/spec.py
+++ b/yapconf/spec.py
@@ -4,16 +4,12 @@ import os
 import sys
 
 import six
+from box import Box
 
 import yapconf
-from box import Box
 from yapconf.docs import generate_markdown_doc
-from yapconf.exceptions import (
-    YapconfItemNotFound,
-    YapconfLoadError,
-    YapconfSourceError,
-    YapconfSpecError,
-)
+from yapconf.exceptions import (YapconfItemNotFound, YapconfLoadError,
+                                YapconfSourceError, YapconfSpecError)
 from yapconf.handlers import ConfigChangeHandler
 from yapconf.items import YapconfDictItem, YapconfListItem, from_specification
 from yapconf.sources import get_source
@@ -79,7 +75,9 @@ class YapconfSpec(object):
     def _load_specification(self, specification):
         if isinstance(specification, six.string_types):
             specification = yapconf.load_file(
-                specification, file_type=self._file_type, klazz=YapconfSpecError,
+                specification,
+                file_type=self._file_type,
+                klazz=YapconfSpecError,
             )
 
         if not isinstance(specification, dict):
@@ -534,7 +532,10 @@ class YapconfSpec(object):
         # We manually generate defaults here so that it is easy to find out
         # if there are defaults for fallbacks that should be applied.
         overrides.append(
-            ("__defaults__", yapconf.flatten(self.defaults, separator=self._separator),)
+            (
+                "__defaults__",
+                yapconf.flatten(self.defaults, separator=self._separator),
+            )
         )
         return overrides
 


### PR DESCRIPTION
Set minimum requirement for ruamel.yaml to 0.15.0

Migrated away from all safe_ prefix functions called for ruamel.yaml

Added backwards support for PyYaml that still utilizes safe_ prefix for functions